### PR TITLE
feat(infra): docker-compose for local dev with localhost-only ports (#4)

### DIFF
--- a/Konnect.Platform/docker-compose.yml
+++ b/Konnect.Platform/docker-compose.yml
@@ -1,0 +1,119 @@
+# Konnect local-dev infrastructure.
+#
+# Every published port binds to 127.0.0.1 only — these services are NOT
+# reachable from the LAN. Credentials below are dev-only; production uses
+# Azure Key Vault / GitHub Secrets via environment overrides.
+#
+# Usage:
+#   cd Konnect.Platform
+#   docker compose up -d                      # core services
+#   docker compose --profile ai-local up -d   # core + Ollama (heavy)
+
+name: konnect
+
+networks:
+  konnect:
+    driver: bridge
+
+volumes:
+  postgres-data:
+  rabbitmq-data:
+  fuseki-data:
+  ollama-data:
+
+services:
+
+  postgres:
+    image: pgvector/pgvector:pg17
+    container_name: konnect-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: konnect
+      POSTGRES_PASSWORD: konnect_dev_only
+      POSTGRES_DB: konnect
+      PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U konnect -d konnect"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    networks: [konnect]
+
+  rabbitmq:
+    image: rabbitmq:4-management
+    container_name: konnect-rabbitmq
+    restart: unless-stopped
+    environment:
+      RABBITMQ_DEFAULT_USER: konnect
+      RABBITMQ_DEFAULT_PASS: konnect_dev_only
+      RABBITMQ_DEFAULT_VHOST: konnect
+    ports:
+      - "127.0.0.1:5672:5672"     # AMQP
+      - "127.0.0.1:15672:15672"   # management UI
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    networks: [konnect]
+
+  fuseki:
+    image: stain/jena-fuseki:5.0.0
+    container_name: konnect-fuseki
+    restart: unless-stopped
+    environment:
+      ADMIN_PASSWORD: konnect_dev_only
+      JVM_ARGS: -Xmx2g
+      FUSEKI_DATASET_1: esco
+    ports:
+      - "127.0.0.1:3030:3030"
+    volumes:
+      - fuseki-data:/fuseki
+      - ./infra/fuseki:/fuseki-init:ro
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3030/$$/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    networks: [konnect]
+
+  smtp4dev:
+    image: rnwood/smtp4dev:v3
+    container_name: konnect-smtp4dev
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:2525:25"     # SMTP
+      - "127.0.0.1:5050:80"     # web UI
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:80/api/Server"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks: [konnect]
+
+  ollama:
+    image: ollama/ollama:latest
+    container_name: konnect-ollama
+    restart: unless-stopped
+    profiles: ["ai-local"]
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks: [konnect]

--- a/Konnect.Platform/infra/fuseki/load-esco.sh
+++ b/Konnect.Platform/infra/fuseki/load-esco.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Loads the ESCO (European Skills, Competences, Qualifications and
+# Occupations) RDF ontology into the Fuseki `esco` dataset using tdb2.tdbloader.
+#
+# Run this AFTER `docker compose up -d` has Fuseki healthy. Run from the host:
+#
+#   docker compose exec fuseki bash /fuseki-init/load-esco.sh
+#
+# Idempotent: if the dataset already has triples, it skips the download.
+# ESCO is published by the European Commission under CC-BY 4.0 — attribution
+# is recorded in the root README.md.
+
+set -euo pipefail
+
+ESCO_VERSION="1.2.0"
+ESCO_BUNDLE_URL="https://esco.ec.europa.eu/sites/default/files/2024-02/ESCO_dataset_release_${ESCO_VERSION}.zip"
+ESCO_STAGING_DIR="/fuseki/databases/esco-staging"
+ESCO_DATASET_DIR="/fuseki/databases/esco"
+ESCO_DOWNLOAD_DIR="/tmp/esco-download"
+
+triple_count_query='ASK { ?s ?p ?o }'
+existing_triples=$(curl -fsS \
+  "http://localhost:3030/esco/sparql?query=$(printf %s "$triple_count_query" | jq -sRr @uri)" \
+  -H "Accept: application/sparql-results+json" 2>/dev/null \
+  | jq -r '.boolean // false')
+
+if [[ "$existing_triples" == "true" ]]; then
+  echo "ESCO dataset already populated — skipping load. Drop the dataset to re-import."
+  exit 0
+fi
+
+echo "Downloading ESCO ${ESCO_VERSION} from EC publication site..."
+mkdir -p "$ESCO_DOWNLOAD_DIR"
+curl -fsSL --retry 3 -o "$ESCO_DOWNLOAD_DIR/esco.zip" "$ESCO_BUNDLE_URL"
+
+echo "Extracting RDF/Turtle files..."
+unzip -q -o "$ESCO_DOWNLOAD_DIR/esco.zip" -d "$ESCO_DOWNLOAD_DIR/extracted"
+
+mkdir -p "$ESCO_STAGING_DIR"
+echo "Loading triples into staging TDB2 store at $ESCO_STAGING_DIR..."
+tdb2.tdbloader \
+  --loc="$ESCO_STAGING_DIR" \
+  "$ESCO_DOWNLOAD_DIR/extracted"/*.ttl
+
+echo "Atomic-swap staging into live dataset at $ESCO_DATASET_DIR..."
+rm -rf "$ESCO_DATASET_DIR.previous"
+if [[ -d "$ESCO_DATASET_DIR" ]]; then
+  mv "$ESCO_DATASET_DIR" "$ESCO_DATASET_DIR.previous"
+fi
+mv "$ESCO_STAGING_DIR" "$ESCO_DATASET_DIR"
+
+echo "Cleaning up download artifacts..."
+rm -rf "$ESCO_DOWNLOAD_DIR"
+
+echo "Done. Restart the fuseki container to pick up the swapped dataset:"
+echo "  docker compose restart fuseki"


### PR DESCRIPTION
## Summary
Local-dev infrastructure stack via Docker Compose. Postgres+pgvector, RabbitMQ, Apache Jena Fuseki, smtp4dev are core; Ollama is opt-in under `--profile ai-local`. **Every published port binds to `127.0.0.1` only** — never reachable from the LAN.

## What's included
- `Konnect.Platform/docker-compose.yml` — 5 services on a user-defined bridge network (`konnect`), named volumes for persistence, healthchecks on all services
- `Konnect.Platform/infra/fuseki/load-esco.sh` — idempotent ESCO 1.2.0 RDF loader (download → `tdb2.tdbloader` → atomic-swap into live dataset)

## Port bindings (all 127.0.0.1)
| Service  | Host port | Container port | Notes |
|---|---|---|---|
| postgres | 5432  | 5432  | user/db `konnect`, dev pwd `konnect_dev_only` |
| rabbitmq | 5672  | 5672  | AMQP, vhost `konnect` |
| rabbitmq | 15672 | 15672 | management UI |
| fuseki   | 3030  | 3030  | `esco` dataset auto-created via env var |
| smtp4dev | 2525  | 25    | SMTP |
| smtp4dev | 5050  | 80    | web UI |
| ollama   | 11434 | 11434 | only with `--profile ai-local` |

## Verified locally (2026-05-02)
- [x] `docker compose config` passes
- [x] `docker compose up -d` brings all 4 core services to `healthy` within ~30s (Fuseki amd64-on-arm64 emulation slowest)
- [x] Postgres responds: `psql -U konnect -d konnect -c "SELECT version();"` → `PostgreSQL 17.9`
- [x] RabbitMQ mgmt API responds: `GET /api/overview` with auth
- [x] Fuseki ping: `GET /$/ping` → timestamp
- [x] Fuseki `esco` dataset exists: `ASK { ?s ?p ?o }` → `boolean: false` (empty, as expected pre-load)
- [x] smtp4dev API responds: `GET /api/Server`
- [x] `lsof -nP -iTCP -sTCP:LISTEN` confirms every published port is `127.0.0.1:*` (none on `0.0.0.0`)

## Notes
- **Fuseki image is amd64** — runs under emulation on Apple Silicon. Slower but functional. Re-evaluate when Apache publishes a multi-arch image.
- **smtp4dev healthcheck uses curl** — wget is not installed in this image.
- **load-esco.sh is manual** — not run by `compose up`. Invoke after first start with `docker compose exec fuseki bash /fuseki-init/load-esco.sh`. ~100MB+ download, takes a few minutes.
- **All credentials are dev-only**, hardcoded in the compose. Production swaps via env overrides + Azure Key Vault / GitHub Secrets.

## Out of scope (deferred)
- CI workflow — #5
- README documenting the quickstart commands — #6
- Konnect.GraphQL scaffold — #10
- wikis folder + Wiki publish workflow — #11

Closes #4
Refs #1