### PR TITLE
ci(infra): GitHub Actions workflow — build, test, EF script, coverage gate (#5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,182 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: "true"
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+  CONFIGURATION: Release
+  SOLUTION_PATH: Konnect.Platform/Konnect.Platform.slnx
+  REPOSITORIES_PROJECT: Konnect.Platform/Konnect.Repositories
+  WEBAPI_PROJECT: Konnect.Platform/Konnect.WebAPI
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: Konnect.Platform/global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore ${{ env.SOLUTION_PATH }}
+
+      - name: Build
+        run: dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration ${{ env.CONFIGURATION }}
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: Konnect.Platform/global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore ${{ env.SOLUTION_PATH }}
+
+      - name: Build
+        run: dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration ${{ env.CONFIGURATION }}
+
+      - name: Test (with TRX logger and code coverage)
+        run: >-
+          dotnet test ${{ env.SOLUTION_PATH }}
+          --no-build
+          --configuration ${{ env.CONFIGURATION }}
+          --logger "trx;LogFileName=test-results.trx"
+          --collect:"XPlat Code Coverage"
+          --results-directory ./TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults/**/*
+          if-no-files-found: ignore
+
+  ef-script:
+    name: EF migrations script
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: Konnect.Platform/global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
+      - name: Install dotnet-ef tool
+        run: dotnet tool install --global dotnet-ef --version 10.*
+
+      - name: Restore
+        run: dotnet restore ${{ env.SOLUTION_PATH }}
+
+      - name: Generate idempotent migrations script (skips when no migrations exist yet)
+        run: |
+          set -euo pipefail
+          if [ -d "${{ env.REPOSITORIES_PROJECT }}/Migrations" ]; then
+            dotnet ef migrations script --idempotent \
+              --project "${{ env.REPOSITORIES_PROJECT }}" \
+              --startup-project "${{ env.WEBAPI_PROJECT }}" \
+              --output ./migrations.sql
+            echo "Idempotent migrations script generated."
+          else
+            echo "No Migrations folder yet (Phase 0 has no DbContext) — skipping ef migrations script."
+          fi
+
+      - name: Upload migrations script
+        if: hashFiles('migrations.sql') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ef-migrations-script
+          path: migrations.sql
+
+  coverage-gate:
+    name: Test-coverage gate (production change must include tests)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout (full history for diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify production .cs changes have matching test changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          prod_changes=$(printf "%s\n" "$changed" \
+            | grep -E '^Konnect\.Platform/Konnect\.(Infrastructure|Services|Repositories|WebAPI|Serverless|Worker|GraphQL)/.*\.cs$' \
+            || true)
+
+          test_changes=$(printf "%s\n" "$changed" \
+            | grep -E '^Konnect\.Platform/Konnect\.Tests/.*\.cs$' \
+            || true)
+
+          if [ -n "$prod_changes" ] && [ -z "$test_changes" ]; then
+            echo "::error::Production .cs files changed but no matching changes under Konnect.Platform/Konnect.Tests/."
+            echo "Production files changed in this PR:"
+            printf "  %s\n" $prod_changes
+            echo ""
+            echo "Per the standing 'every change ships with tests' rule, this PR must add or update tests."
+            exit 1
+          fi
+
+          if [ -z "$prod_changes" ]; then
+            echo "No production .cs changes in this PR — coverage gate not applicable."
+          else
+            echo "Production .cs changes detected and matching test changes are present."
+            echo ""
+            echo "Production files changed:"
+            printf "  %s\n" $prod_changes
+            echo ""
+            echo "Test files changed:"
+            printf "  %s\n" $test_changes
+          fi


### PR DESCRIPTION
Closes #5. Part of #1.

Adds `.github/workflows/ci.yml` with four jobs, triggered on `pull_request` to `main` and `push` to `main`.

## Jobs

| Job | Does |
|---|---|
| `build` | `dotnet restore` + `dotnet build --configuration Release` against `Konnect.Platform.slnx` |
| `test` | `dotnet test --no-build` with TRX logger and `XPlat Code Coverage`; uploads `TestResults/**` as an artifact |
| `ef-script` | Installs `dotnet-ef` and runs `dotnet ef migrations script --idempotent` if `Konnect.Repositories/Migrations` exists. No-op in Phase 0 (no DbContext yet) so the job logs a clear skip message instead of failing |
| `coverage-gate` | On PRs only: fails the build if any `Konnect.Platform/Konnect.{Infrastructure,Services,Repositories,WebAPI,Serverless,Worker,GraphQL}/**/*.cs` file changed without a matching change under `Konnect.Platform/Konnect.Tests/**/*.cs`. Enforces the standing "every change ships with tests" rule |

## Acceptance criteria checklist

- [x] Triggers on `pull_request` to `main` and `push` to `main`
- [x] `build`, `test`, `ef-script`, `coverage-gate` jobs present
- [x] All jobs cache NuGet packages keyed on `Directory.Packages.props` + csproj hashes
- [x] Uses `GITHUB_TOKEN` only — no PAT, `permissions: contents: read`
- [x] SDK pinned via `global-json-file: Konnect.Platform/global.json` (10.0.201)

## Local validation

```
$ dotnet build Konnect.Platform.slnx --configuration Release
Build succeeded. 0 Warning(s) 0 Error(s)

$ dotnet test Konnect.Platform.slnx --no-build --configuration Release \
    --logger "trx;LogFileName=test-results.trx" \
    --collect:"XPlat Code Coverage"
Passed!  - Failed: 0, Passed: 3, Skipped: 0, Total: 3
```

The PR for this task is the test — when CI runs against `dev/5`, all four jobs should report green. `coverage-gate` is expected to pass because this PR contains no production `.cs` changes.

## Notes for the future

- The `ef-script` job will start producing real output once Phase 1 lands the initial DbContext + migration.
- `coverage-gate` is intentionally a structural heuristic (per-PR diff) rather than a coverage-percentage threshold; it can be tightened once the codebase has more surface area.