### PR TITLE
feat(graphql): scaffold Konnect.GraphQL csproj — HotChocolate, hosted by WebAPI (#10)

### DIFF
--- a/Konnect.Platform/Directory.Packages.props
+++ b/Konnect.Platform/Directory.Packages.props
@@ -10,6 +10,11 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
   </ItemGroup>
 
+  <ItemGroup Label="GraphQL (HotChocolate)">
+    <PackageVersion Include="HotChocolate.AspNetCore" Version="16.0.0" />
+    <PackageVersion Include="HotChocolate.Types" Version="16.0.0" />
+  </ItemGroup>
+
   <ItemGroup Label="Azure Functions (Serverless)">
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />

--- a/Konnect.Platform/Konnect.GraphQL/GraphQLServiceCollectionExtensions.cs
+++ b/Konnect.Platform/Konnect.GraphQL/GraphQLServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+using Konnect.GraphQL.Schema;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Konnect.GraphQL;
+
+public static class GraphQLServiceCollectionExtensions
+{
+    public static IServiceCollection AddKonnectGraphQL(this IServiceCollection services)
+    {
+        services
+            .AddGraphQLServer()
+            .AddQueryType<Query>();
+
+        return services;
+    }
+}

--- a/Konnect.Platform/Konnect.GraphQL/Konnect.GraphQL.csproj
+++ b/Konnect.Platform/Konnect.GraphQL/Konnect.GraphQL.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- CA1822: HotChocolate resolver methods are instance methods by convention even when -->
+    <!-- they don't access `this` directly (state usually arrives via injected parameters). -->
+    <NoWarn>$(NoWarn);CA1822</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="HotChocolate.AspNetCore" />
+    <PackageReference Include="HotChocolate.Types" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Konnect.Infrastructure\Konnect.Infrastructure.csproj" />
+    <ProjectReference Include="..\Konnect.Services\Konnect.Services.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Konnect.Platform/Konnect.GraphQL/Schema/Query.cs
+++ b/Konnect.Platform/Konnect.GraphQL/Schema/Query.cs
@@ -1,0 +1,6 @@
+namespace Konnect.GraphQL.Schema;
+
+public partial class Query
+{
+    public string Healthcheck() => "ok";
+}

--- a/Konnect.Platform/Konnect.Platform.slnx
+++ b/Konnect.Platform/Konnect.Platform.slnx
@@ -2,6 +2,7 @@
   <Project Path="Konnect.Infrastructure/Konnect.Infrastructure.csproj" />
   <Project Path="Konnect.Services/Konnect.Services.csproj" />
   <Project Path="Konnect.Repositories/Konnect.Repositories.csproj" />
+  <Project Path="Konnect.GraphQL/Konnect.GraphQL.csproj" />
   <Project Path="Konnect.WebAPI/Konnect.WebAPI.csproj" />
   <Project Path="Konnect.Serverless/Konnect.Serverless.csproj" />
   <Project Path="Konnect.Worker/Konnect.Worker.csproj" />

--- a/Konnect.Platform/Konnect.Tests/Architecture/SolutionStructureTests.cs
+++ b/Konnect.Platform/Konnect.Tests/Architecture/SolutionStructureTests.cs
@@ -29,6 +29,18 @@ public class SolutionStructureTests
     }
 
     [Fact]
+    public void WebApi_References_GraphQL()
+    {
+        var webApiAssembly = Assembly.Load("Konnect.WebAPI");
+
+        var referencedAssemblyNames = webApiAssembly.GetReferencedAssemblies()
+            .Select(referencedAssembly => referencedAssembly.Name)
+            .ToArray();
+
+        Assert.Contains("Konnect.GraphQL", referencedAssemblyNames);
+    }
+
+    [Fact]
     public void Infrastructure_ContainsNoConcreteImplementationClasses()
     {
         var infrastructureAssembly = Assembly.Load("Konnect.Infrastructure");

--- a/Konnect.Platform/Konnect.Tests/GraphQL/HealthcheckTests.cs
+++ b/Konnect.Platform/Konnect.Tests/GraphQL/HealthcheckTests.cs
@@ -1,0 +1,26 @@
+using HotChocolate;
+using HotChocolate.Execution;
+using Konnect.GraphQL;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Konnect.Tests.GraphQL;
+
+public class HealthcheckTests
+{
+    [Fact]
+    public async Task GraphQL_HealthcheckQuery_Returns_Ok()
+    {
+        var services = new ServiceCollection();
+        services.AddKonnectGraphQL();
+        await using var serviceProvider = services.BuildServiceProvider();
+
+        var executor = await serviceProvider
+            .GetRequiredService<IRequestExecutorProvider>()
+            .GetExecutorAsync();
+
+        await using var result = await executor.ExecuteAsync("{ healthcheck }");
+
+        var json = result.ToJson();
+        Assert.Contains("\"healthcheck\": \"ok\"", json);
+    }
+}

--- a/Konnect.Platform/Konnect.Tests/Konnect.Tests.csproj
+++ b/Konnect.Platform/Konnect.Tests/Konnect.Tests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\Konnect.Infrastructure\Konnect.Infrastructure.csproj" />
     <ProjectReference Include="..\Konnect.Services\Konnect.Services.csproj" />
     <ProjectReference Include="..\Konnect.Repositories\Konnect.Repositories.csproj" />
+    <ProjectReference Include="..\Konnect.GraphQL\Konnect.GraphQL.csproj" />
     <ProjectReference Include="..\Konnect.WebAPI\Konnect.WebAPI.csproj" />
     <ProjectReference Include="..\Konnect.Serverless\Konnect.Serverless.csproj" />
     <ProjectReference Include="..\Konnect.Worker\Konnect.Worker.csproj" />

--- a/Konnect.Platform/Konnect.WebAPI/Konnect.WebAPI.csproj
+++ b/Konnect.Platform/Konnect.WebAPI/Konnect.WebAPI.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\Konnect.Infrastructure\Konnect.Infrastructure.csproj" />
     <ProjectReference Include="..\Konnect.Services\Konnect.Services.csproj" />
     <ProjectReference Include="..\Konnect.Repositories\Konnect.Repositories.csproj" />
+    <ProjectReference Include="..\Konnect.GraphQL\Konnect.GraphQL.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Konnect.Platform/Konnect.WebAPI/Program.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Program.cs
@@ -1,3 +1,5 @@
+using Konnect.GraphQL;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -5,6 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddKonnectGraphQL();
 
 var app = builder.Build();
 
@@ -19,5 +22,6 @@ app.UseHttpsRedirection();
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapGraphQL();
 
 app.Run();


### PR DESCRIPTION
Closes #10. Part of #1.

Adds the 8th project, \`Konnect.GraphQL\`, with HotChocolate wired up. Skeleton only — real Query/Mutation/Subscription types and resolvers ship alongside their feature work in later phases.

## What's in the box

| File | Purpose |
|---|---|
| \`Konnect.GraphQL/Konnect.GraphQL.csproj\` | New csproj. References \`Konnect.Infrastructure\` + \`Konnect.Services\`. Pulls \`HotChocolate.AspNetCore\` + \`HotChocolate.Types\` |
| \`Konnect.GraphQL/Schema/Query.cs\` | \`partial class Query\` with a placeholder \`Healthcheck()\` field that returns \`"ok"\` |
| \`Konnect.GraphQL/GraphQLServiceCollectionExtensions.cs\` | \`services.AddKonnectGraphQL()\` — calls \`AddGraphQLServer().AddQueryType<Query>()\` |
| \`Konnect.WebAPI/Program.cs\` | Now calls \`builder.Services.AddKonnectGraphQL()\` and \`app.MapGraphQL()\` |
| \`Konnect.WebAPI/Konnect.WebAPI.csproj\` | Project reference to \`Konnect.GraphQL\` |
| \`Konnect.Tests/Konnect.Tests.csproj\` | Project reference to \`Konnect.GraphQL\` |
| \`Konnect.Tests/GraphQL/HealthcheckTests.cs\` | Schema smoke test (see below) |
| \`Konnect.Tests/Architecture/SolutionStructureTests.cs\` | New test \`WebApi_References_GraphQL\` pins the structural rule |
| \`Konnect.Platform.slnx\` | \`Konnect.GraphQL\` added |
| \`Directory.Packages.props\` | Pinned \`HotChocolate.AspNetCore\` + \`HotChocolate.Types\` at \`16.0.0\` |

## Acceptance criteria checklist

- [x] New project at \`Konnect.Platform/Konnect.GraphQL/Konnect.GraphQL.csproj\` (\`Microsoft.NET.Sdk\`)
- [x] References \`Konnect.Infrastructure\` and \`Konnect.Services\`
- [x] \`HotChocolate.AspNetCore\` and \`HotChocolate.Types\` versions added to \`Directory.Packages.props\`
- [x] \`Konnect.GraphQL/Schema/Query.cs\` — \`partial class Query\` with placeholder \`Healthcheck()\`
- [x] \`AddKonnectGraphQL()\` extension method
- [x] \`Konnect.WebAPI/Program.cs\` calls \`AddKonnectGraphQL()\` and \`MapGraphQL()\`
- [x] \`Konnect.WebAPI.csproj\` references \`Konnect.GraphQL\`
- [x] \`Konnect.GraphQL\` added to the slnx
- [x] \`Konnect.Tests\` references \`Konnect.GraphQL\`

## On the smoke test approach

The original criteria suggested a \`POST /graphql\` test using \`WebApplicationFactory<Program>\`. That collides with \`Konnect.Serverless\` (both use top-level statements, both emit \`<global>::Program\`, the test compiler can't pick one), and resolving the collision required either a marker class in the WebAPI project or InternalsVisibleTo plumbing — both of which are test-only concerns leaking into production code.

This PR keeps the fix purely test-side: the smoke test executes \`{ healthcheck }\` directly against HotChocolate's \`IRequestExecutorProvider\`, asserting the JSON contains \`"healthcheck": "ok"\`. That validates schema construction + resolver wiring (which is the actual behaviour we care about for the placeholder). The Program.cs integration is covered structurally by the new \`WebApi_References_GraphQL\` test plus the build itself — Program.cs literally won't compile if \`AddKonnectGraphQL()\` is misnamed or unwired.

When real domain types land, full HTTP integration tests can use a marker type (or any of the standard workarounds) at that point — separate concern.

## Other notes

- \`Konnect.GraphQL.csproj\` suppresses CA1822: HotChocolate resolver methods are instance methods by convention even when they don't access \`this\` (which is the case for the placeholder).
- HotChocolate 16's API: the executor lookup interface is now \`IRequestExecutorProvider.GetExecutorAsync()\` (was \`IRequestExecutorResolver.GetRequestExecutorAsync()\` in older versions). Used in the test.
- \`Konnect.WebAPI/Program.cs\` line endings normalized to LF to match the project's \`.editorconfig\`. The functional change is just three lines: \`using Konnect.GraphQL;\`, \`builder.Services.AddKonnectGraphQL();\`, and \`app.MapGraphQL();\` — the rest of the diff on that file is EOL.

## Local validation

```
$ dotnet build Konnect.Platform.slnx --configuration Release
Build succeeded. 0 Warning(s) 0 Error(s)

$ dotnet test Konnect.Platform.slnx --configuration Release
Passed!  - Failed: 0, Passed: 5, Skipped: 0, Total: 5
```

## Out of scope

Real domain types (Job, Application, Profile) — those come with their feature work in Phase 1+.