### PR TITLE
docs: add root README + smtp4dev wiki page (closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,91 @@
+# Konnect
+
+Konnect is a job-board backend built in .NET 10. It pairs PostgreSQL (with `pgvector` for semantic search) with an Apache Jena Fuseki triplestore that holds the [ESCO](https://esco.ec.europa.eu/) skills/occupation ontology, so search supports lexical, semantic, and ontology-aware skill expansion. Async work (resume parsing, embedding generation, notifications, alerts) runs through RabbitMQ via MassTransit. AI providers — Gemini today, Ollama for local dev, OpenAI as a future option — sit behind a single `IAiClient` interface. Both REST and GraphQL are exposed from one ASP.NET Core process.
+
+This is the backend only. There is no frontend in this repo.
+
+## Tech stack
+
+| Concern | Choice |
+|---|---|
+| Runtime | .NET 10 (SDK pinned in [`Konnect.Platform/global.json`](Konnect.Platform/global.json)) |
+| Web framework | ASP.NET Core (REST controllers + GraphQL via HotChocolate) |
+| Relational + vector store | PostgreSQL 17 with `pgvector` |
+| Knowledge graph | Apache Jena Fuseki, populated with ESCO RDF |
+| Messaging | RabbitMQ via MassTransit |
+| AI | `IAiClient` with Gemini (default), Ollama (local), OpenAI (future) |
+| Local mail catcher | smtp4dev (dev only — prod uses a real provider) |
+| Tests | xUnit (integration tests will use Testcontainers when repository / messaging code lands) |
+| CI | GitHub Actions — see [`.github/workflows/ci.yml`](.github/workflows/ci.yml) |
+
+## Repo layout
+
+The .NET solution lives in [`Konnect.Platform/`](Konnect.Platform/). The repo root holds only this README and Git/GitHub metadata.
+
+| Project | Role |
+|---|---|
+| [`Konnect.Infrastructure`](Konnect.Platform/Konnect.Infrastructure/) | Interfaces, models, contracts. No implementations. |
+| [`Konnect.Services`](Konnect.Platform/Konnect.Services/) | Business logic; implements `Infrastructure` interfaces. Domain packages are folders inside this project. |
+| [`Konnect.Repositories`](Konnect.Platform/Konnect.Repositories/) | EF Core `DbContext` + repository implementations. |
+| [`Konnect.GraphQL`](Konnect.Platform/Konnect.GraphQL/) | HotChocolate schema. Hosted by `Konnect.WebAPI`. |
+| [`Konnect.WebAPI`](Konnect.Platform/Konnect.WebAPI/) | ASP.NET Core entry point — REST + GraphQL. |
+| [`Konnect.Worker`](Konnect.Platform/Konnect.Worker/) | `Microsoft.Extensions.Hosting` worker that hosts MassTransit consumers. |
+| [`Konnect.Serverless`](Konnect.Platform/Konnect.Serverless/) | Azure Functions (isolated worker) — scheduled jobs only. |
+| [`Konnect.Tests`](Konnect.Platform/Konnect.Tests/) | xUnit. Folder structure mirrors source. |
+
+The deeper layout, dependency graph, and per-component documentation live in the [wiki](https://github.com/win-son-dev/konnect-server/wiki) (auto-published from [`wikis/`](wikis/)).
+
+## Quickstart
+
+Prerequisites: .NET SDK 10.0.201 (auto-resolved via `global.json`), Docker, GitHub CLI.
+
+```bash
+# 1. Clone
+gh auth login
+gh repo clone win-son-dev/konnect-server
+cd konnect-server
+
+# 2. Bring up local infra (postgres, rabbitmq, fuseki, smtp4dev)
+cd Konnect.Platform
+docker compose up -d
+
+# 3. Build
+dotnet build Konnect.Platform.slnx
+
+# 4. Run the API (REST + GraphQL on the launch profile's port)
+dotnet run --project Konnect.WebAPI
+
+# 5. Run the worker host (consumers will appear here as they're added)
+dotnet run --project Konnect.Worker
+```
+
+`docker compose ps` should show every service `(healthy)` before the API starts. Connection details, ports, and credentials are documented in the [Local Development wiki page](https://github.com/win-son-dev/konnect-server/wiki/Local-Development).
+
+## Local-only by design
+
+Every published port in [`Konnect.Platform/docker-compose.yml`](Konnect.Platform/docker-compose.yml) binds to `127.0.0.1` — nothing in the dev stack is reachable from the LAN. The credentials in compose (`konnect_dev_only`) are convenience defaults for development and are not safe outside the developer's machine. Production credentials live in Azure Key Vault / GitHub Secrets and are injected via environment overrides into the actual hosting platform.
+
+## Workflow
+
+Issue-first, PR-based — never direct commits to `main`.
+
+1. Open a Story issue + sub-issues on GitHub. One PR per sub-issue.
+2. Branch off `main`: `dev/<issue-number>` for features/stories/tasks, `bug/<issue-number>` for bugs.
+3. Make small, focused commits. Reference the issue (`Closes #N`).
+4. Open a PR. CI runs automatically — build, test, EF migration script, structural coverage gate.
+5. After review, merge with a plain merge commit (not squash).
+6. Pull `main`, branch again.
+
+Documentation lives in the wiki and ships in the same PR as the code change it describes — a code change with documentation impact (new endpoint, new container, changed wiring) updates the relevant wiki page in the same PR. The wiki is part of the codebase.
+
+## Documentation
+
+| Where | What |
+|---|---|
+| `README.md` (this file) | Landing page, quickstart, attributions. The only `.md` committed at the repo root. |
+| [`wikis/`](wikis/) | Deep-dive documentation, auto-synced to the [GitHub Wiki](https://github.com/win-son-dev/konnect-server/wiki) by [`.github/workflows/publish-wiki.yml`](.github/workflows/publish-wiki.yml). |
+| `docs/` (gitignored) | Local-only working notes — ADRs, planning notes, design sketches. Not committed. |
+
+## Attribution
+
+This project uses the **European Skills, Competences, Qualifications and Occupations (ESCO)** classification, © European Union, 2024, licensed under the [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/) licence. ESCO is not bundled with this repo — it is downloaded into the Fuseki container at first run by [`Konnect.Platform/infra/fuseki/load-esco.sh`](Konnect.Platform/infra/fuseki/load-esco.sh). See the [Apache Jena Fuseki wiki page](https://github.com/win-son-dev/konnect-server/wiki/Apache-Jena-Fuseki) for the loader pipeline and dataset structure.

--- a/wikis/Home.md
+++ b/wikis/Home.md
@@ -13,6 +13,7 @@ This wiki is the deep-dive layer for collaborators. The repo `README.md` is the 
   - [PostgreSQL](infrastructure/PostgreSQL)
   - [RabbitMQ](infrastructure/RabbitMQ)
   - [Apache Jena Fuseki](infrastructure/Apache-Jena-Fuseki)
+  - [smtp4dev](infrastructure/smtp4dev)
   - [Docker Compose](infrastructure/Docker-Compose)
   - [CI Pipeline](infrastructure/CI-Pipeline)
 - **Features** — feature pages get added when each feature is implemented.

--- a/wikis/Local-Development.md
+++ b/wikis/Local-Development.md
@@ -45,11 +45,12 @@ flowchart LR
     Dev -->|5432| Postgres[(postgres<br/>pgvector/pgvector:pg17)]
     Dev -->|5672 AMQP<br/>15672 management| Rabbit[(rabbitmq<br/>4-management)]
     Dev -->|3030| Fuseki[(fuseki<br/>stain/jena-fuseki:5.0.0)]
+    Dev -->|2525 SMTP<br/>5050 UI| Smtp[(smtp4dev<br/>rnwood/smtp4dev:v3)]
     Dev -. profile=ai-local<br/>11434 .-> Ollama[(ollama)]
 
     classDef infra fill:#264653,stroke:#1b2a3a,color:#fff
     classDef opt fill:#6c757d,stroke:#343a40,color:#fff
-    class Postgres,Rabbit,Fuseki infra
+    class Postgres,Rabbit,Fuseki,Smtp infra
     class Ollama opt
 ```
 
@@ -59,6 +60,8 @@ flowchart LR
 | RabbitMQ AMQP | `amqp://konnect:konnect_dev_only@127.0.0.1:5672/konnect` | user `konnect` / password `konnect_dev_only` / vhost `konnect` |
 | RabbitMQ management UI | http://127.0.0.1:15672 | as above |
 | Fuseki | http://127.0.0.1:3030 | admin password `konnect_dev_only` |
+| smtp4dev SMTP | `127.0.0.1:2525` | none (dev catcher — captures, never relays) |
+| smtp4dev inbox UI | http://127.0.0.1:5050 | none |
 | Ollama (optional) | http://127.0.0.1:11434 | none — start with `docker compose --profile ai-local up -d` |
 
 ## Day-to-day commands

--- a/wikis/infrastructure/Docker-Compose.md
+++ b/wikis/infrastructure/Docker-Compose.md
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-A single file that defines every long-running infrastructure dependency Konnect needs locally — Postgres, RabbitMQ, Fuseki, plus an opt-in Ollama for local AI. Versions are pinned, ports are bound to localhost, healthchecks are defined, and named volumes preserve state across restarts. The goal: a new contributor runs one command and has a working dev environment in under five minutes.
+A single file that defines every long-running infrastructure dependency Konnect needs locally — Postgres, RabbitMQ, Fuseki, smtp4dev (a fake SMTP catcher so dev mail never leaves the machine), plus an opt-in Ollama for local AI. Versions are pinned, ports are bound to localhost, healthchecks are defined, and named volumes preserve state across restarts. The goal: a new contributor runs one command and has a working dev environment in under five minutes.
 
 ## File layout
 
@@ -22,6 +22,7 @@ services:
   postgres:    ...
   rabbitmq:    ...
   fuseki:      ...
+  smtp4dev:    ...
   ollama:      ... profiles: ["ai-local"]    # opt-in, not started by default
 ```
 
@@ -45,7 +46,7 @@ Compose profiles let one file describe both a "default" stack and an "everything
 
 | Profile | Brings up | When to use |
 |---|---|---|
-| *(none)* | postgres, rabbitmq, fuseki | Default — `docker compose up -d` |
+| *(none)* | postgres, rabbitmq, fuseki, smtp4dev | Default — `docker compose up -d` |
 | `ai-local` | + ollama (heavy: ~5–10 GB once a model is pulled) | When working on AI features locally and you don't want to burn Gemini quota |
 
 ```bash
@@ -96,6 +97,7 @@ flowchart LR
 | `postgres` | `pg_isready -U konnect -d konnect` | Confirms Postgres is accepting connections, not just running |
 | `rabbitmq` | `rabbitmq-diagnostics -q ping` | Confirms the broker is fully booted (it boots slowly) |
 | `fuseki` | `curl -fsS http://localhost:3030/$/ping` | Confirms the SPARQL endpoint is serving |
+| `smtp4dev` | `curl -fsS http://localhost:80/api/Server` | Confirms the SMTP catcher's management API is up (the SMTP listener is up by then too) |
 | `ollama` | `ollama list` | Confirms the LLM runtime is responsive |
 
 `docker compose ps` shows the health column — wait for everything to say `(healthy)` before running the WebAPI.

--- a/wikis/infrastructure/Overview.md
+++ b/wikis/infrastructure/Overview.md
@@ -9,6 +9,7 @@ flowchart TB
         Postgres[(postgres<br/>pgvector/pgvector:pg17)]
         Rabbit[(rabbitmq<br/>4-management)]
         Fuseki[(fuseki<br/>stain/jena-fuseki:5.0.0)]
+        Smtp[(smtp4dev<br/>rnwood/smtp4dev:v3)]
         Ollama[(ollama — opt-in profile)]
     end
 
@@ -20,7 +21,7 @@ flowchart TB
 
     classDef store fill:#264653,stroke:#1b2a3a,color:#fff
     classDef proc fill:#7b2cbf,stroke:#3c096c,color:#fff
-    class Postgres,Rabbit,Fuseki,Ollama store
+    class Postgres,Rabbit,Fuseki,Smtp,Ollama store
     class WebAPI,Worker,Serverless proc
 ```
 
@@ -29,6 +30,7 @@ flowchart TB
 | PostgreSQL + pgvector | `pgvector/pgvector:pg17` | 5432 | [PostgreSQL](PostgreSQL) |
 | RabbitMQ | `rabbitmq:4-management` | 5672 (AMQP), 15672 (UI) | [RabbitMQ](RabbitMQ) |
 | Apache Jena Fuseki | `stain/jena-fuseki:5.0.0` | 3030 | [Apache Jena Fuseki](Apache-Jena-Fuseki) |
+| smtp4dev | `rnwood/smtp4dev:v3` | 2525 (SMTP), 5050 (UI) | [smtp4dev](smtp4dev) |
 | Ollama (opt-in) | `ollama/ollama:latest` | 11434 | — |
 
 ## Tooling not in compose

--- a/wikis/infrastructure/smtp4dev.md
+++ b/wikis/infrastructure/smtp4dev.md
@@ -1,0 +1,57 @@
+# smtp4dev
+
+> Local SMTP catcher running via docker compose. Outbound mail in dev never leaves the developer's machine — it lands in smtp4dev's inbox so we can inspect it. No code in the repo sends mail yet; the page will expand when the notifications/alerts pipeline ships.
+
+## What's running
+
+The image is `rnwood/smtp4dev:v3` — a fake SMTP server with a web UI that captures every message sent to it instead of relaying. Production uses a real provider (e.g. SendGrid) wired through the same `notification.email` exchange.
+
+```mermaid
+flowchart LR
+    Compose["docker compose up -d"] --> Container[konnect-smtp4dev<br/>rnwood/smtp4dev:v3]
+    Container --> Smtp[127.0.0.1:2525<br/>SMTP]
+    Container --> UI[127.0.0.1:5050<br/>web UI]
+    Container --> Health["healthcheck:<br/>curl /api/Server"]
+
+    classDef infra fill:#3a86ff,stroke:#1d4e89,color:#fff
+    class Container,Smtp,UI,Health infra
+```
+
+## Connection
+
+| Setting | Value |
+|---|---|
+| SMTP host | `127.0.0.1` |
+| SMTP port | `2525` |
+| Web UI | http://127.0.0.1:5050 |
+| Auth | none (dev only) |
+| TLS | none (dev only) |
+
+The container's internal SMTP port is `25`; the host port `2525` avoids the privileged-port range. Application config in dev should target port `2525`.
+
+## Healthcheck
+
+Compose runs `curl -fsS http://localhost:80/api/Server` every 30s after a 15s startup grace period — the smtp4dev management API responds once the SMTP listener is up.
+
+## Volume
+
+None. smtp4dev keeps captured messages in memory; restarting the container clears the inbox. That's intentional — the inbox is meant to be ephemeral, not a long-term archive.
+
+## Common operations
+
+```bash
+# Open the inbox
+open http://127.0.0.1:5050
+
+# Send a smoke-test email from the host (requires `swaks`)
+swaks --to test@konnect.local --from dev@konnect.local \
+      --server 127.0.0.1:2525 --body "smtp4dev wiring check"
+```
+
+## Code touchpoints
+
+| File | Role |
+|---|---|
+| [`Konnect.Platform/docker-compose.yml`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/docker-compose.yml) | Container, healthcheck, port bindings |
+
+No application code talks to smtp4dev yet. When the notifications pipeline lands (an `EmailConsumer` reading `notification.email`), the dev configuration will point its SMTP host at `127.0.0.1:2525` and this page will document the wiring.


### PR DESCRIPTION
## Summary

- Adds the repo's first `README.md` at the root: project pitch, tech stack, 8-csproj repo layout, quickstart, workflow rules, and the **ESCO CC-BY 4.0 attribution** (which lives in `README.md` per the docs-gitignored rule — there is no `NOTICE.md`).
- Adds [`wikis/infrastructure/smtp4dev.md`](wikis/infrastructure/smtp4dev.md) and threads smtp4dev through [`wikis/Home.md`](wikis/Home.md), [`wikis/Local-Development.md`](wikis/Local-Development.md), [`wikis/infrastructure/Overview.md`](wikis/infrastructure/Overview.md), and [`wikis/infrastructure/Docker-Compose.md`](wikis/infrastructure/Docker-Compose.md) — it had been missed when those pages were first written.
- ADR-0001 (8-csproj layout decision) is authored locally under `docs/adr/0001-project-layout.md` and is **gitignored** per the docs rule. Verified `git status` shows no `docs/` entry.

## Why smtp4dev stays
Originally tracked in #15 as a removal. Reversed: smtp4dev gives the future `notification.email` pipeline somewhere to land in dev without sending real mail. The wiki page is part of this PR rather than waiting for the consumer to land — keeps the infrastructure section complete.

## What this is *not*
No code changes. Docs-only. CI's structural coverage gate doesn't apply (no `Konnect.{Infrastructure,Services,Repositories,WebAPI,Serverless,Worker,GraphQL}/*.cs` touched).

## Test plan
- [ ] CI green (build + test + ef-script; coverage-gate skipped because no production `.cs` changed)
- [ ] Wiki publish workflow fires on merge and updates the GitHub Wiki with the new smtp4dev page
- [ ] Visual check: README renders correctly on the GitHub repo landing page
- [ ] Visual check: `git status` from a clean checkout shows no `docs/` (rule honored)

Closes #6.