### PR TITLE
docs: add All Rights Reserved license notice (closes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ Documentation lives in the wiki and ships in the same PR as the code change it d
 ## Attribution
 
 This project uses the **European Skills, Competences, Qualifications and Occupations (ESCO)** classification, © European Union, 2024, licensed under the [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/) licence. ESCO is not bundled with this repo — it is downloaded into the Fuseki container at first run by [`Konnect.Platform/infra/fuseki/load-esco.sh`](Konnect.Platform/infra/fuseki/load-esco.sh). See the [Apache Jena Fuseki wiki page](https://github.com/win-son-dev/konnect-server/wiki/Apache-Jena-Fuseki) for the loader pipeline and dataset structure.
+
+## License
+
+**Copyright (c) 2026 win-son-dev. All rights reserved.**
+
+This source code is published for portfolio viewing only. No part of this codebase may be copied, modified, distributed, executed, or used in any form — commercial or non-commercial — without prior written permission from the copyright holder.
+
+External contributions are not accepted at this time.


### PR DESCRIPTION
## Summary

Adds a \`## License\` section to the root [README.md](README.md) with an explicit All Rights Reserved notice:

\`\`\`
Copyright (c) 2026 win-son-dev. All rights reserved.

This source code is published for portfolio viewing only. No part of this
codebase may be copied, modified, distributed, executed, or used in any
form — commercial or non-commercial — without prior written permission
from the copyright holder.

External contributions are not accepted at this time.
\`\`\`

## Why no LICENSE file

Without any license file, the legal default for an unlicensed work is already All Rights Reserved — but most readers don't know that. Adding a \`LICENSE\` file would *grant* rights (every standard LICENSE template grants something), which is the opposite of intent.

So the repo stays unlicensed in the formal sense, and the README states the position plainly. This is the standard approach for source-available portfolio code that the author wants visible but not reusable.

## What this preserves
- Future-you can fork the repo into a private workspace and commercialize it freely (you own the copyright; the notice doesn't bind you).
- AGPL/dual-licensing is still available later if you change your mind — you'd just add a \`LICENSE\` file at that point.
- ESCO CC-BY 4.0 attribution (separate from this license question) stays in the existing Attribution section.

## Test plan
- [ ] CI green (build + test + ef-script; coverage-gate skipped — no production \`.cs\` changed)
- [ ] README renders correctly on the GitHub repo landing page with the new \`## License\` section visible
- [ ] No \`LICENSE\` file created (verify with \`git status\` after merge)

Closes #18.