### PR TITLE
chore(auth): point dev appsettings at the real Auth0 tenant and recruiter audience

### DIFF
--- a/Konnect.Platform/Konnect.WebAPI/appsettings.Development.json
+++ b/Konnect.Platform/Konnect.WebAPI/appsettings.Development.json
@@ -9,8 +9,8 @@
     "Postgres": "Host=127.0.0.1;Port=5432;Database=konnect;Username=konnect;Password=konnect_dev_only;Include Error Detail=true"
   },
   "Auth0": {
-    "Domain": "konnect-dev.au.auth0.com",
+    "Domain": "dev-7tezygfwayj84twt.us.auth0.com",
     "SeekerAudience": "https://api.konnect.dev/seeker",
-    "EmployerAudience": "https://api.konnect.dev/employer"
+    "EmployerAudience": "https://api.konnect.dev/recruiter"
   }
 }


### PR DESCRIPTION
Closes #48.

## Summary

Two-line change to `Konnect.Platform/Konnect.WebAPI/appsettings.Development.json`:

- `Auth0:Domain`: `konnect-dev.au.auth0.com` → `dev-7tezygfwayj84twt.us.auth0.com` — the actual Konnect dev Auth0 tenant.
- `Auth0:EmployerAudience` value: `https://api.konnect.dev/employer` → `https://api.konnect.dev/recruiter` — aligns the audience URL with the frontend folder name and JWT role claim (`Recruiter`). The config **key** is still `EmployerAudience`; renaming the key (plus the matching property in `Auth0Settings`, the tests in `KonnectWebApplicationFactory` / `AuthenticationPipelineTests`, and wiki references in `wikis/api/Authentication-Auth0.md`) is owed in a follow-up PR.

## Why now

End-to-end Auth0 setup is otherwise complete (single Application + audience-split, Post-Login Action stamping `external_id` GUID + `role` from audience + `email`, frontend `.env.local` files for both apps, recruiter-API client_grant in place). The backend's `JwtBearer` middleware in `Program.cs` was the last piece pointing at the wrong issuer/audience — this PR fixes that so `/api/me` validates real Auth0-issued tokens and returns the populated claim triple in dev.

## Test plan

- [x] `dotnet test` — 31/31 pass (test fixture defines its own audience constants in `KonnectWebApplicationFactory`, so the production-config edit doesn't affect test outcomes).
- [x] Manual end-to-end: signed up via recruiters frontend (`http://localhost:3000`) → Auth0 Universal Login → callback succeeds → temp `/api/test-me` route in the recruiters Next.js app fetched `http://localhost:5220/api/me` with the access token → backend returned `{ "externalId": "<guid>", "role": "Recruiter", "email": "<email>" }` with HTTP 200. Temp route since removed.