### PR TITLE
feat(onboarding): post-Auth0 recruiter + seeker onboarding handshake

### DIFF
--- a/Konnect.Platform/Directory.Packages.props
+++ b/Konnect.Platform/Directory.Packages.props
@@ -8,6 +8,7 @@
   <ItemGroup Label="ASP.NET Core / Hosting">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup Label="GraphQL (HotChocolate)">

--- a/Konnect.Platform/Konnect.Infrastructure/Repositories/DatabaseOptions.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Repositories/DatabaseOptions.cs
@@ -1,0 +1,21 @@
+namespace Konnect.Infrastructure.Repositories;
+
+/// <summary>
+/// Strongly-typed configuration for the Postgres-backed
+/// <c>KonnectDbContext</c>. Bound from the <c>Database</c> section of
+/// <c>appsettings.json</c> (and overridden per-environment via the standard
+/// <c>appsettings.{Environment}.json</c>, environment variables, or
+/// in-memory test settings). Keeping every infrastructure dependency behind
+/// its own typed options class — <see cref="DatabaseOptions"/>,
+/// <c>Auth0Settings</c>, future Redis / MinIO / Auth0-management options —
+/// means the test pipeline can override one slice via
+/// <c>services.Configure&lt;T&gt;(...)</c> without racing the
+/// host-configuration build order, and the production code never reads
+/// loose <c>IConfiguration</c> strings inline.
+/// </summary>
+public sealed record DatabaseOptions
+{
+    public const string SectionName = "Database";
+
+    public string PostgresConnectionString { get; set; } = string.Empty;
+}

--- a/Konnect.Platform/Konnect.Infrastructure/Repositories/ICompanyRepository.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Repositories/ICompanyRepository.cs
@@ -1,0 +1,31 @@
+using Konnect.Infrastructure.Entities;
+
+namespace Konnect.Infrastructure.Repositories;
+
+/// <summary>
+/// Data-plane access for <see cref="Company"/>. Phase 1 covers the slug-keyed
+/// public lookup, idempotency-side existence checks, and the atomic
+/// company-plus-first-recruiter insert that recruiter onboarding relies on.
+/// The atomic insert lives here (rather than spanning two repositories) so
+/// the transaction boundary stays inside a single leaf — services orchestrate
+/// validation and call this one method instead of juggling a unit of work.
+/// </summary>
+public interface ICompanyRepository
+{
+    Task<Company?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    Task<Company?> GetBySlugAsync(string slug, CancellationToken cancellationToken);
+
+    Task<bool> SlugExistsAsync(string slug, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Persists a new <paramref name="company"/> together with its first
+    /// <paramref name="firstRecruiter"/> in a single Postgres transaction.
+    /// Either both rows commit or neither does — there is no partial state
+    /// where a recruiter exists without their company or vice versa.
+    /// </summary>
+    Task AddWithFirstRecruiterAsync(
+        Company company,
+        RecruiterUser firstRecruiter,
+        CancellationToken cancellationToken);
+}

--- a/Konnect.Platform/Konnect.Infrastructure/Repositories/IUserRepository.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Repositories/IUserRepository.cs
@@ -1,0 +1,23 @@
+using Konnect.Infrastructure.Entities;
+
+namespace Konnect.Infrastructure.Repositories;
+
+/// <summary>
+/// Reads against the polymorphic <see cref="User"/> hierarchy keyed off the
+/// Auth0 <c>external_id</c> Guid. Onboarding services lean on this to decide
+/// whether a JWT-authenticated caller already has a domain row (idempotency)
+/// or needs one provisioned. Subtype-specific writes for first-time
+/// provisioning live on dedicated members:
+/// <list type="bullet">
+///   <item><see cref="AddJobSeekerAsync"/> — creates the seeker row</item>
+///   <item>Recruiter creation is paired with company creation and lives on
+///   <see cref="ICompanyRepository.AddWithFirstRecruiterAsync"/> so both rows
+///   land in one transaction.</item>
+/// </list>
+/// </summary>
+public interface IUserRepository
+{
+    Task<User?> GetByIdAsync(Guid externalId, CancellationToken cancellationToken);
+
+    Task AddJobSeekerAsync(JobSeekerUser jobSeeker, CancellationToken cancellationToken);
+}

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Authentication/Auth0Settings.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Authentication/Auth0Settings.cs
@@ -15,18 +15,18 @@ public sealed record Auth0Settings
     /// JwtBearer Authority is derived as <c>https://{Domain}/</c> and used to
     /// fetch the JWKS document and validate the <c>iss</c> claim.
     /// </summary>
-    public string Domain { get; init; } = string.Empty;
+    public string Domain { get; set; } = string.Empty;
 
     /// <summary>
     /// The audience identifier of the seeker-side Auth0 API resource —
     /// becomes the JWT <c>aud</c> for tokens issued to the Seeker SPA.
     /// Example: <c>https://api.konnect.dev/seeker</c>.
     /// </summary>
-    public string SeekerAudience { get; init; } = string.Empty;
+    public string SeekerAudience { get; set; } = string.Empty;
 
     /// <summary>
     /// The audience identifier of the employer-side Auth0 API resource.
     /// Example: <c>https://api.konnect.dev/employer</c>.
     /// </summary>
-    public string EmployerAudience { get; init; } = string.Empty;
+    public string EmployerAudience { get; set; } = string.Empty;
 }

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/IJobSeekerOnboardingService.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/IJobSeekerOnboardingService.cs
@@ -1,0 +1,16 @@
+namespace Konnect.Infrastructure.Services.Onboarding;
+
+/// <summary>
+/// Provisions the <c>JobSeekerUser</c> row keyed off the Auth0
+/// <c>external_id</c> claim of the authenticated caller. Idempotent on
+/// <paramref name="externalId"/> — re-invocations return the existing seeker
+/// without mutating state.
+/// </summary>
+public interface IJobSeekerOnboardingService
+{
+    Task<JobSeekerOnboardingResult> OnboardAsync(
+        Guid externalId,
+        string email,
+        OnboardJobSeekerInput input,
+        CancellationToken cancellationToken);
+}

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/IRecruiterOnboardingService.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/IRecruiterOnboardingService.cs
@@ -1,0 +1,17 @@
+namespace Konnect.Infrastructure.Services.Onboarding;
+
+/// <summary>
+/// Provisions the <c>RecruiterUser</c> + owning <c>Company</c> rows that
+/// Phase-1 recruiter-scoped features depend on, keyed off the Auth0
+/// <c>external_id</c> claim of the authenticated caller. Idempotent on
+/// <paramref name="externalId"/> — re-invocations return the existing pair
+/// without mutating state.
+/// </summary>
+public interface IRecruiterOnboardingService
+{
+    Task<RecruiterOnboardingResult> OnboardAsync(
+        Guid externalId,
+        string email,
+        OnboardRecruiterInput input,
+        CancellationToken cancellationToken);
+}

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/JobSeekerOnboardingResult.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/JobSeekerOnboardingResult.cs
@@ -1,0 +1,22 @@
+using Konnect.Infrastructure.Entities;
+
+namespace Konnect.Infrastructure.Services.Onboarding;
+
+/// <summary>
+/// Tagged-union outcome of a job-seeker onboarding attempt. The controller
+/// pattern-matches on the concrete case to pick the HTTP status code:
+/// <list type="bullet">
+///   <item><see cref="Created"/> — first onboarding, 201</item>
+///   <item><see cref="Existing"/> — idempotent replay, 200</item>
+/// </list>
+/// </summary>
+public abstract record JobSeekerOnboardingResult
+{
+    private JobSeekerOnboardingResult()
+    {
+    }
+
+    public sealed record Created(JobSeekerUser JobSeeker) : JobSeekerOnboardingResult;
+
+    public sealed record Existing(JobSeekerUser JobSeeker) : JobSeekerOnboardingResult;
+}

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/OnboardJobSeekerInput.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/OnboardJobSeekerInput.cs
@@ -1,0 +1,11 @@
+namespace Konnect.Infrastructure.Services.Onboarding;
+
+/// <summary>
+/// SPA-supplied payload for the post-Auth0 job-seeker onboarding handshake.
+/// Identity (<c>external_id</c>, <c>email</c>) comes from the JWT. All
+/// fields here are profile-side values the seeker can edit later.
+/// </summary>
+public sealed record OnboardJobSeekerInput(
+    string? Headline,
+    string? Location,
+    bool OpenToWork);

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/OnboardRecruiterInput.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/OnboardRecruiterInput.cs
@@ -1,0 +1,17 @@
+namespace Konnect.Infrastructure.Services.Onboarding;
+
+/// <summary>
+/// SPA-supplied payload for the post-Auth0 recruiter onboarding handshake.
+/// The recruiter's identity (<c>external_id</c>, <c>email</c>) is taken from
+/// the JWT — never from this input — so a recruiter cannot onboard another
+/// user. Input is the company-plus-personal data that Auth0 doesn't capture
+/// during sign-up.
+/// </summary>
+public sealed record OnboardRecruiterInput(
+    string CompanyName,
+    string CompanySlug,
+    string? CompanyDescription,
+    string? CompanyWebsiteUrl,
+    string FirstName,
+    string LastName,
+    string JobTitle);

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/RecruiterOnboardingResult.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding/RecruiterOnboardingResult.cs
@@ -1,0 +1,25 @@
+using Konnect.Infrastructure.Entities;
+
+namespace Konnect.Infrastructure.Services.Onboarding;
+
+/// <summary>
+/// Tagged-union outcome of a recruiter onboarding attempt. The controller
+/// pattern-matches on the concrete case to pick the HTTP status code:
+/// <list type="bullet">
+///   <item><see cref="Created"/> — first onboarding, 201</item>
+///   <item><see cref="Existing"/> — idempotent replay, 200</item>
+///   <item><see cref="SlugConflict"/> — slug already owned by a different recruiter, 409</item>
+/// </list>
+/// </summary>
+public abstract record RecruiterOnboardingResult
+{
+    private RecruiterOnboardingResult()
+    {
+    }
+
+    public sealed record Created(Guid RecruiterId, Company Company) : RecruiterOnboardingResult;
+
+    public sealed record Existing(Guid RecruiterId, Company Company) : RecruiterOnboardingResult;
+
+    public sealed record SlugConflict(string Slug) : RecruiterOnboardingResult;
+}

--- a/Konnect.Platform/Konnect.Repositories/CompanyRepository.cs
+++ b/Konnect.Platform/Konnect.Repositories/CompanyRepository.cs
@@ -4,15 +4,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Konnect.Repositories;
 
-public sealed class CompanyRepository : ICompanyRepository
+public sealed class CompanyRepository(KonnectDbContext dbContext) : ICompanyRepository
 {
-    private readonly KonnectDbContext dbContext;
-
-    public CompanyRepository(KonnectDbContext dbContext)
-    {
-        this.dbContext = dbContext;
-    }
-
     public Task<Company?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
         => dbContext.Companies
             .FirstOrDefaultAsync(company => company.Id == id, cancellationToken);

--- a/Konnect.Platform/Konnect.Repositories/CompanyRepository.cs
+++ b/Konnect.Platform/Konnect.Repositories/CompanyRepository.cs
@@ -1,0 +1,50 @@
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Konnect.Repositories;
+
+public sealed class CompanyRepository : ICompanyRepository
+{
+    private readonly KonnectDbContext dbContext;
+
+    public CompanyRepository(KonnectDbContext dbContext)
+    {
+        this.dbContext = dbContext;
+    }
+
+    public Task<Company?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+        => dbContext.Companies
+            .FirstOrDefaultAsync(company => company.Id == id, cancellationToken);
+
+    public Task<Company?> GetBySlugAsync(string slug, CancellationToken cancellationToken)
+        => dbContext.Companies
+            .FirstOrDefaultAsync(company => company.Slug == slug, cancellationToken);
+
+    public Task<bool> SlugExistsAsync(string slug, CancellationToken cancellationToken)
+        => dbContext.Companies
+            .AnyAsync(company => company.Slug == slug, cancellationToken);
+
+    /// <summary>
+    /// The transaction is owned here, not by the calling service, so that
+    /// the repository remains the single boundary touching the data store —
+    /// matches the rule that services orchestrate while repositories are
+    /// leaves. SaveChanges runs once with both entities staged; if it fails
+    /// (slug unique-index violation, FK violation) the transaction rolls
+    /// back and neither row is persisted.
+    /// </summary>
+    public async Task AddWithFirstRecruiterAsync(
+        Company company,
+        RecruiterUser firstRecruiter,
+        CancellationToken cancellationToken)
+    {
+        await using var transaction = await dbContext.Database
+            .BeginTransactionAsync(cancellationToken);
+
+        dbContext.Companies.Add(company);
+        dbContext.Recruiters.Add(firstRecruiter);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
+}

--- a/Konnect.Platform/Konnect.Repositories/Configurations/CompanyConfiguration.cs
+++ b/Konnect.Platform/Konnect.Repositories/Configurations/CompanyConfiguration.cs
@@ -32,9 +32,15 @@ public sealed class CompanyConfiguration : IEntityTypeConfiguration<Company>
             .HasDefaultValue(false);
 
         builder.Property(company => company.CreatedAt)
-            .IsRequired();
+            .IsRequired()
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .ValueGeneratedOnAdd();
 
         builder.Property(company => company.UpdatedAt)
-            .IsRequired();
+            .IsRequired()
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .ValueGeneratedOnAddOrUpdate();
+
+        builder.ToTable(table => table.HasTrigger("set_updated_at_companies"));
     }
 }

--- a/Konnect.Platform/Konnect.Repositories/Configurations/UserConfiguration.cs
+++ b/Konnect.Platform/Konnect.Repositories/Configurations/UserConfiguration.cs
@@ -30,10 +30,21 @@ public sealed class UserConfiguration : IEntityTypeConfiguration<User>
 
         builder.HasIndex(user => user.Email);
 
+        // Both timestamps are owned by Postgres: CURRENT_TIMESTAMP fills
+        // them on INSERT, the set_updated_at trigger refreshes UpdatedAt on
+        // every UPDATE. Services never assign these — keeps app- and DB-clock
+        // skew impossible and removes a TimeProvider dependency from every
+        // write path.
         builder.Property(user => user.CreatedAt)
-            .IsRequired();
+            .IsRequired()
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .ValueGeneratedOnAdd();
 
         builder.Property(user => user.UpdatedAt)
-            .IsRequired();
+            .IsRequired()
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .ValueGeneratedOnAddOrUpdate();
+
+        builder.ToTable(table => table.HasTrigger("set_updated_at_users"));
     }
 }

--- a/Konnect.Platform/Konnect.Repositories/JobRepository.cs
+++ b/Konnect.Platform/Konnect.Repositories/JobRepository.cs
@@ -4,15 +4,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Konnect.Repositories;
 
-public sealed class JobRepository : IJobRepository
+public sealed class JobRepository(KonnectDbContext dbContext) : IJobRepository
 {
-    private readonly KonnectDbContext dbContext;
-
-    public JobRepository(KonnectDbContext dbContext)
-    {
-        this.dbContext = dbContext;
-    }
-
     public Task<JobPosting?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
         => dbContext.JobPostings
             .FirstOrDefaultAsync(jobPosting => jobPosting.Id == id, cancellationToken);

--- a/Konnect.Platform/Konnect.Repositories/KonnectDbContext.cs
+++ b/Konnect.Platform/Konnect.Repositories/KonnectDbContext.cs
@@ -10,13 +10,8 @@ namespace Konnect.Repositories;
 /// is owned by Auth0; the <c>users</c> table holds profile rows keyed by the
 /// Auth0-generated <c>external_id</c> Guid (see <see cref="User.Id"/>).
 /// </summary>
-public class KonnectDbContext : DbContext
+public class KonnectDbContext(DbContextOptions<KonnectDbContext> options) : DbContext(options)
 {
-    public KonnectDbContext(DbContextOptions<KonnectDbContext> options)
-        : base(options)
-    {
-    }
-
     public DbSet<User> Users => Set<User>();
 
     public DbSet<JobSeekerUser> JobSeekers => Set<JobSeekerUser>();

--- a/Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.Designer.cs
+++ b/Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Konnect.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Konnect.Repositories.Migrations
 {
     [DbContext(typeof(KonnectDbContext))]
-    partial class KonnectDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508121429_AddDbManagedTimestamps")]
+    partial class AddDbManagedTimestamps
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.cs
+++ b/Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Konnect.Repositories.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDbManagedTimestamps : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "updated_at",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP",
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "created_at",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP",
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "updated_at",
+                table: "companies",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP",
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "created_at",
+                table: "companies",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP",
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            // Single shared trigger function used by every table that owns a
+            // managed updated_at column. Postgres has no MySQL-style
+            // ON UPDATE clause, so the BEFORE UPDATE trigger is the
+            // idiomatic equivalent.
+            migrationBuilder.Sql(@"
+                CREATE OR REPLACE FUNCTION set_updated_at()
+                RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.updated_at = CURRENT_TIMESTAMP;
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+            ");
+
+            migrationBuilder.Sql(@"
+                CREATE TRIGGER set_updated_at_users
+                BEFORE UPDATE ON users
+                FOR EACH ROW
+                EXECUTE FUNCTION set_updated_at();
+            ");
+
+            migrationBuilder.Sql(@"
+                CREATE TRIGGER set_updated_at_companies
+                BEFORE UPDATE ON companies
+                FOR EACH ROW
+                EXECUTE FUNCTION set_updated_at();
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS set_updated_at_companies ON companies;");
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS set_updated_at_users ON users;");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS set_updated_at();");
+
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "updated_at",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "created_at",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "updated_at",
+                table: "companies",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "created_at",
+                table: "companies",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
+        }
+    }
+}

--- a/Konnect.Platform/Konnect.Repositories/RepositoriesServiceCollectionExtensions.cs
+++ b/Konnect.Platform/Konnect.Repositories/RepositoriesServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Konnect.Infrastructure.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Konnect.Repositories;
 
@@ -11,17 +12,23 @@ namespace Konnect.Repositories;
 /// </summary>
 public static class RepositoriesServiceCollectionExtensions
 {
-    public static IServiceCollection AddKonnectRepositories(
-        this IServiceCollection services,
-        string postgresConnectionString)
+    public static IServiceCollection AddKonnectRepositories(this IServiceCollection services)
     {
-        services.AddDbContext<KonnectDbContext>(options =>
+        // Resolve the connection string lazily through IOptions so test
+        // overrides (services.Configure<DatabaseOptions>(...)) win over the
+        // production binding regardless of registration order.
+        services.AddDbContext<KonnectDbContext>((serviceProvider, options) =>
         {
-            options.UseNpgsql(postgresConnectionString);
+            var databaseOptions = serviceProvider
+                .GetRequiredService<IOptions<DatabaseOptions>>().Value;
+
+            options.UseNpgsql(databaseOptions.PostgresConnectionString);
             options.UseSnakeCaseNamingConvention();
         });
 
         services.AddScoped<IJobRepository, JobRepository>();
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<ICompanyRepository, CompanyRepository>();
 
         return services;
     }

--- a/Konnect.Platform/Konnect.Repositories/UserRepository.cs
+++ b/Konnect.Platform/Konnect.Repositories/UserRepository.cs
@@ -4,15 +4,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Konnect.Repositories;
 
-public sealed class UserRepository : IUserRepository
+public sealed class UserRepository(KonnectDbContext dbContext) : IUserRepository
 {
-    private readonly KonnectDbContext dbContext;
-
-    public UserRepository(KonnectDbContext dbContext)
-    {
-        this.dbContext = dbContext;
-    }
-
     public Task<User?> GetByIdAsync(Guid externalId, CancellationToken cancellationToken)
         => dbContext.Users
             .FirstOrDefaultAsync(user => user.Id == externalId, cancellationToken);

--- a/Konnect.Platform/Konnect.Repositories/UserRepository.cs
+++ b/Konnect.Platform/Konnect.Repositories/UserRepository.cs
@@ -1,0 +1,25 @@
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Konnect.Repositories;
+
+public sealed class UserRepository : IUserRepository
+{
+    private readonly KonnectDbContext dbContext;
+
+    public UserRepository(KonnectDbContext dbContext)
+    {
+        this.dbContext = dbContext;
+    }
+
+    public Task<User?> GetByIdAsync(Guid externalId, CancellationToken cancellationToken)
+        => dbContext.Users
+            .FirstOrDefaultAsync(user => user.Id == externalId, cancellationToken);
+
+    public async Task AddJobSeekerAsync(JobSeekerUser jobSeeker, CancellationToken cancellationToken)
+    {
+        dbContext.JobSeekers.Add(jobSeeker);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Konnect.Platform/Konnect.Services/Konnect.Services.csproj
+++ b/Konnect.Platform/Konnect.Services/Konnect.Services.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Konnect.Infrastructure\Konnect.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/Konnect.Platform/Konnect.Services/Onboarding/JobSeekerOnboardingService.cs
+++ b/Konnect.Platform/Konnect.Services/Onboarding/JobSeekerOnboardingService.cs
@@ -1,0 +1,50 @@
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Repositories;
+using Konnect.Infrastructure.Services.Onboarding;
+
+namespace Konnect.Services.Onboarding;
+
+public sealed class JobSeekerOnboardingService : IJobSeekerOnboardingService
+{
+    private readonly IUserRepository userRepository;
+
+    public JobSeekerOnboardingService(IUserRepository userRepository)
+    {
+        this.userRepository = userRepository;
+    }
+
+    public async Task<JobSeekerOnboardingResult> OnboardAsync(
+        Guid externalId,
+        string email,
+        OnboardJobSeekerInput input,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+
+        var existing = await userRepository.GetByIdAsync(externalId, cancellationToken);
+        if (existing is JobSeekerUser existingSeeker)
+        {
+            return new JobSeekerOnboardingResult.Existing(existingSeeker);
+        }
+
+        if (existing is not null)
+        {
+            throw new InvalidOperationException(
+                $"User {externalId} is already provisioned as {existing.GetType().Name}, cannot onboard as JobSeeker.");
+        }
+
+        var seeker = new JobSeekerUser
+        {
+            Id = externalId,
+            Email = email,
+            Headline = input.Headline ?? string.Empty,
+            Location = input.Location ?? string.Empty,
+            OpenToWork = input.OpenToWork,
+        };
+
+        await userRepository.AddJobSeekerAsync(seeker, cancellationToken);
+
+        return new JobSeekerOnboardingResult.Created(seeker);
+    }
+}

--- a/Konnect.Platform/Konnect.Services/Onboarding/JobSeekerOnboardingService.cs
+++ b/Konnect.Platform/Konnect.Services/Onboarding/JobSeekerOnboardingService.cs
@@ -4,15 +4,8 @@ using Konnect.Infrastructure.Services.Onboarding;
 
 namespace Konnect.Services.Onboarding;
 
-public sealed class JobSeekerOnboardingService : IJobSeekerOnboardingService
+public sealed class JobSeekerOnboardingService(IUserRepository userRepository) : IJobSeekerOnboardingService
 {
-    private readonly IUserRepository userRepository;
-
-    public JobSeekerOnboardingService(IUserRepository userRepository)
-    {
-        this.userRepository = userRepository;
-    }
-
     public async Task<JobSeekerOnboardingResult> OnboardAsync(
         Guid externalId,
         string email,

--- a/Konnect.Platform/Konnect.Services/Onboarding/RecruiterOnboardingService.cs
+++ b/Konnect.Platform/Konnect.Services/Onboarding/RecruiterOnboardingService.cs
@@ -4,19 +4,10 @@ using Konnect.Infrastructure.Services.Onboarding;
 
 namespace Konnect.Services.Onboarding;
 
-public sealed class RecruiterOnboardingService : IRecruiterOnboardingService
+public sealed class RecruiterOnboardingService(
+    IUserRepository userRepository,
+    ICompanyRepository companyRepository) : IRecruiterOnboardingService
 {
-    private readonly IUserRepository userRepository;
-    private readonly ICompanyRepository companyRepository;
-
-    public RecruiterOnboardingService(
-        IUserRepository userRepository,
-        ICompanyRepository companyRepository)
-    {
-        this.userRepository = userRepository;
-        this.companyRepository = companyRepository;
-    }
-
     public async Task<RecruiterOnboardingResult> OnboardAsync(
         Guid externalId,
         string email,

--- a/Konnect.Platform/Konnect.Services/Onboarding/RecruiterOnboardingService.cs
+++ b/Konnect.Platform/Konnect.Services/Onboarding/RecruiterOnboardingService.cs
@@ -1,0 +1,98 @@
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Repositories;
+using Konnect.Infrastructure.Services.Onboarding;
+
+namespace Konnect.Services.Onboarding;
+
+public sealed class RecruiterOnboardingService : IRecruiterOnboardingService
+{
+    private readonly IUserRepository userRepository;
+    private readonly ICompanyRepository companyRepository;
+
+    public RecruiterOnboardingService(
+        IUserRepository userRepository,
+        ICompanyRepository companyRepository)
+    {
+        this.userRepository = userRepository;
+        this.companyRepository = companyRepository;
+    }
+
+    public async Task<RecruiterOnboardingResult> OnboardAsync(
+        Guid externalId,
+        string email,
+        OnboardRecruiterInput input,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        ValidateInput(input);
+
+        var existing = await userRepository.GetByIdAsync(externalId, cancellationToken);
+        if (existing is RecruiterUser existingRecruiter)
+        {
+            // Idempotent replay — already onboarded. Return the existing pair
+            // without touching the DB; the SPA's retry-after-network-hiccup
+            // path lands here.
+            var existingCompany = await companyRepository.GetByIdAsync(
+                existingRecruiter.CompanyId,
+                cancellationToken)
+                ?? throw new InvalidOperationException(
+                    $"Recruiter {existingRecruiter.Id} references missing company {existingRecruiter.CompanyId}.");
+
+            return new RecruiterOnboardingResult.Existing(existingRecruiter.Id, existingCompany);
+        }
+
+        if (existing is not null)
+        {
+            // The external_id is already provisioned for a different audience
+            // (a JobSeekerUser). Auth0's pre-registration action enforces a
+            // single audience per identity, so reaching here means a bug
+            // upstream — surface loudly rather than silently shadowing.
+            throw new InvalidOperationException(
+                $"User {externalId} is already provisioned as {existing.GetType().Name}, cannot onboard as Recruiter.");
+        }
+
+        if (await companyRepository.SlugExistsAsync(input.CompanySlug, cancellationToken))
+        {
+            return new RecruiterOnboardingResult.SlugConflict(input.CompanySlug);
+        }
+
+        var companyId = Guid.NewGuid();
+
+        // CreatedAt / UpdatedAt are owned by Postgres (DEFAULT CURRENT_TIMESTAMP
+        // + set_updated_at trigger). Leaving them at the .NET default tells
+        // EF to skip them on INSERT and read back what the DB stamped.
+        var company = new Company
+        {
+            Id = companyId,
+            Name = input.CompanyName,
+            Slug = input.CompanySlug,
+            Description = input.CompanyDescription,
+            WebsiteUrl = input.CompanyWebsiteUrl,
+            Verified = false,
+        };
+
+        var recruiter = new RecruiterUser
+        {
+            Id = externalId,
+            Email = email,
+            CompanyId = companyId,
+            FirstName = input.FirstName,
+            LastName = input.LastName,
+            JobTitle = input.JobTitle,
+        };
+
+        await companyRepository.AddWithFirstRecruiterAsync(company, recruiter, cancellationToken);
+
+        return new RecruiterOnboardingResult.Created(recruiter.Id, company);
+    }
+
+    private static void ValidateInput(OnboardRecruiterInput input)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.CompanyName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.CompanySlug);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.FirstName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.LastName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.JobTitle);
+    }
+}

--- a/Konnect.Platform/Konnect.Services/ServicesServiceCollectionExtensions.cs
+++ b/Konnect.Platform/Konnect.Services/ServicesServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+using Konnect.Infrastructure.Services.Onboarding;
+using Konnect.Services.Onboarding;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Konnect.Services;
+
+/// <summary>
+/// Single registration entry point for everything in <c>Konnect.Services</c>.
+/// All Services are <c>Scoped</c> so they share the request-scoped DbContext
+/// transitively reached through their injected repositories.
+/// </summary>
+public static class ServicesServiceCollectionExtensions
+{
+    public static IServiceCollection AddKonnectServices(this IServiceCollection services)
+    {
+        services.AddScoped<IRecruiterOnboardingService, RecruiterOnboardingService>();
+        services.AddScoped<IJobSeekerOnboardingService, JobSeekerOnboardingService>();
+
+        return services;
+    }
+}

--- a/Konnect.Platform/Konnect.Tests/Infrastructure/PostgresFixture.cs
+++ b/Konnect.Platform/Konnect.Tests/Infrastructure/PostgresFixture.cs
@@ -12,8 +12,7 @@ namespace Konnect.Tests.Infrastructure;
 /// </summary>
 public sealed class PostgresFixture : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer container = new PostgreSqlBuilder()
-        .WithImage("pgvector/pgvector:pg17")
+    private readonly PostgreSqlContainer container = new PostgreSqlBuilder("pgvector/pgvector:pg17")
         .WithDatabase("konnect_test")
         .WithUsername("konnect_test")
         .WithPassword("konnect_test_only")
@@ -29,10 +28,7 @@ public sealed class PostgresFixture : IAsyncLifetime
         await dbContext.Database.MigrateAsync();
     }
 
-    public async Task DisposeAsync()
-    {
-        await container.DisposeAsync();
-    }
+    public async Task DisposeAsync() => await container.DisposeAsync();
 
     public KonnectDbContext CreateDbContext()
     {
@@ -45,8 +41,14 @@ public sealed class PostgresFixture : IAsyncLifetime
     }
 }
 
+/// <summary>
+/// xUnit collection-definition marker. Test classes that need the shared
+/// Postgres container declare <c>[Collection(DatabaseTestSuite.Name)]</c> —
+/// xUnit groups them under one collection so they share a single
+/// <see cref="PostgresFixture"/> instance across the test run.
+/// </summary>
 [CollectionDefinition(Name)]
-public sealed class DatabaseCollection : ICollectionFixture<PostgresFixture>
+public sealed class DatabaseTestSuite : ICollectionFixture<PostgresFixture>
 {
     public const string Name = "Database";
 }

--- a/Konnect.Platform/Konnect.Tests/Repositories/JobRepositoryTests.cs
+++ b/Konnect.Platform/Konnect.Tests/Repositories/JobRepositoryTests.cs
@@ -10,16 +10,9 @@ namespace Konnect.Tests.Repositories;
 /// CRUD method against a real Postgres container. Pins the JobRepository
 /// integration contract for sub-issue #25 to build on.
 /// </summary>
-[Collection(DatabaseCollection.Name)]
-public class JobRepositoryTests
+[Collection(DatabaseTestSuite.Name)]
+public class JobRepositoryTests(PostgresFixture postgresFixture)
 {
-    private readonly PostgresFixture postgresFixture;
-
-    public JobRepositoryTests(PostgresFixture postgresFixture)
-    {
-        this.postgresFixture = postgresFixture;
-    }
-
     [Fact]
     public async Task Should_RoundtripJobPosting_Through_AddGetUpdateDelete()
     {

--- a/Konnect.Platform/Konnect.Tests/Repositories/SchemaTests.cs
+++ b/Konnect.Platform/Konnect.Tests/Repositories/SchemaTests.cs
@@ -9,16 +9,9 @@ namespace Konnect.Tests.Repositories;
 /// expected post-Auth0-pivot shape, this test starts failing. Especially
 /// guards against the asp_net_* Identity tables sneaking back in.
 /// </summary>
-[Collection(DatabaseCollection.Name)]
-public class SchemaTests
+[Collection(DatabaseTestSuite.Name)]
+public class SchemaTests(PostgresFixture postgresFixture)
 {
-    private readonly PostgresFixture postgresFixture;
-
-    public SchemaTests(PostgresFixture postgresFixture)
-    {
-        this.postgresFixture = postgresFixture;
-    }
-
     [Fact]
     public async Task Should_HaveExpectedTableSet_When_AllMigrationsApplied()
     {

--- a/Konnect.Platform/Konnect.Tests/Services/Onboarding/JobSeekerOnboardingServiceTests.cs
+++ b/Konnect.Platform/Konnect.Tests/Services/Onboarding/JobSeekerOnboardingServiceTests.cs
@@ -1,0 +1,113 @@
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Repositories;
+using Konnect.Infrastructure.Services.Onboarding;
+using Konnect.Services.Onboarding;
+using NSubstitute;
+
+namespace Konnect.Tests.Services.Onboarding;
+
+/// <summary>
+/// Pins the orchestration logic of <see cref="JobSeekerOnboardingService"/>:
+/// idempotency on existing seekers, audience mismatch detection, and the
+/// happy-path entity shape that gets handed to the repository.
+/// </summary>
+public class JobSeekerOnboardingServiceTests
+{
+    private readonly IUserRepository userRepository = Substitute.For<IUserRepository>();
+    private readonly JobSeekerOnboardingService service;
+
+    public JobSeekerOnboardingServiceTests()
+    {
+        service = new JobSeekerOnboardingService(userRepository);
+    }
+
+    [Fact]
+    public async Task Should_CreateNewSeeker_When_NoExistingUser()
+    {
+        var externalId = Guid.NewGuid();
+        userRepository.GetByIdAsync(externalId, Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+
+        var input = new OnboardJobSeekerInput(
+            Headline: "Senior Engineer",
+            Location: "Sydney",
+            OpenToWork: true);
+
+        var result = await service.OnboardAsync(externalId, "alice@example.test", input, CancellationToken.None);
+
+        var created = Assert.IsType<JobSeekerOnboardingResult.Created>(result);
+        Assert.Equal(externalId, created.JobSeeker.Id);
+        Assert.Equal("Senior Engineer", created.JobSeeker.Headline);
+        Assert.Equal("Sydney", created.JobSeeker.Location);
+        Assert.True(created.JobSeeker.OpenToWork);
+
+        await userRepository.Received(1).AddJobSeekerAsync(
+            Arg.Is<JobSeekerUser>(seeker => seeker.Id == externalId && seeker.Email == "alice@example.test"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_DefaultEmptyStringsForOptionalFields()
+    {
+        var externalId = Guid.NewGuid();
+        userRepository.GetByIdAsync(externalId, Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+
+        var input = new OnboardJobSeekerInput(Headline: null, Location: null, OpenToWork: false);
+
+        var result = await service.OnboardAsync(externalId, "alice@example.test", input, CancellationToken.None);
+
+        var created = Assert.IsType<JobSeekerOnboardingResult.Created>(result);
+        Assert.Equal(string.Empty, created.JobSeeker.Headline);
+        Assert.Equal(string.Empty, created.JobSeeker.Location);
+        Assert.False(created.JobSeeker.OpenToWork);
+    }
+
+    [Fact]
+    public async Task Should_ReturnExisting_When_SeekerAlreadyExists()
+    {
+        var externalId = Guid.NewGuid();
+        var existingSeeker = new JobSeekerUser
+        {
+            Id = externalId,
+            Email = "alice@example.test",
+            Headline = "Existing Headline",
+            Location = "Existing Location",
+            OpenToWork = true,
+        };
+        userRepository.GetByIdAsync(externalId, Arg.Any<CancellationToken>())
+            .Returns(existingSeeker);
+
+        var input = new OnboardJobSeekerInput("Different", "Different", false);
+
+        var result = await service.OnboardAsync(externalId, "alice@example.test", input, CancellationToken.None);
+
+        var existing = Assert.IsType<JobSeekerOnboardingResult.Existing>(result);
+        Assert.Equal("Existing Headline", existing.JobSeeker.Headline);
+
+        await userRepository.DidNotReceive().AddJobSeekerAsync(
+            Arg.Any<JobSeekerUser>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_ThrowInvalidOperation_When_UserExistsAsRecruiter()
+    {
+        var externalId = Guid.NewGuid();
+        userRepository.GetByIdAsync(externalId, Arg.Any<CancellationToken>())
+            .Returns(new RecruiterUser
+            {
+                Id = externalId,
+                Email = "alice@acme.test",
+                CompanyId = Guid.NewGuid(),
+                FirstName = "Alice",
+                LastName = "Anderson",
+                JobTitle = "Recruiter",
+            });
+
+        var input = new OnboardJobSeekerInput(null, null, false);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.OnboardAsync(externalId, "alice@acme.test", input, CancellationToken.None));
+    }
+}

--- a/Konnect.Platform/Konnect.Tests/Services/Onboarding/RecruiterOnboardingServiceTests.cs
+++ b/Konnect.Platform/Konnect.Tests/Services/Onboarding/RecruiterOnboardingServiceTests.cs
@@ -1,0 +1,152 @@
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Repositories;
+using Konnect.Infrastructure.Services.Onboarding;
+using Konnect.Services.Onboarding;
+using NSubstitute;
+
+namespace Konnect.Tests.Services.Onboarding;
+
+/// <summary>
+/// Pins the orchestration logic of <see cref="RecruiterOnboardingService"/>:
+/// idempotency on existing recruiters, slug-conflict short-circuit, audience
+/// mismatch detection, and the happy-path entity shape that gets handed to
+/// the repository.
+/// </summary>
+public class RecruiterOnboardingServiceTests
+{
+    private readonly IUserRepository userRepository = Substitute.For<IUserRepository>();
+    private readonly ICompanyRepository companyRepository = Substitute.For<ICompanyRepository>();
+    private readonly RecruiterOnboardingService service;
+
+    public RecruiterOnboardingServiceTests()
+    {
+        service = new RecruiterOnboardingService(userRepository, companyRepository);
+    }
+
+    [Fact]
+    public async Task Should_CreateNewCompanyAndRecruiter_When_NoExistingUser()
+    {
+        var externalId = Guid.NewGuid();
+        userRepository.GetByIdAsync(externalId, Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+        companyRepository.SlugExistsAsync("acme", Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var input = NewRecruiterInput("acme");
+
+        var result = await service.OnboardAsync(externalId, "alice@acme.test", input, CancellationToken.None);
+
+        var created = Assert.IsType<RecruiterOnboardingResult.Created>(result);
+        Assert.Equal(externalId, created.RecruiterId);
+        Assert.Equal("acme", created.Company.Slug);
+        Assert.Equal("Acme Corp", created.Company.Name);
+        Assert.False(created.Company.Verified);
+
+        await companyRepository.Received(1).AddWithFirstRecruiterAsync(
+            Arg.Is<Company>(company => company.Slug == "acme" && company.Id != Guid.Empty),
+            Arg.Is<RecruiterUser>(recruiter =>
+                recruiter.Id == externalId
+                && recruiter.Email == "alice@acme.test"
+                && recruiter.FirstName == "Alice"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_ReturnExisting_When_RecruiterAlreadyExists()
+    {
+        var externalId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        var existingRecruiter = new RecruiterUser
+        {
+            Id = externalId,
+            Email = "alice@acme.test",
+            CompanyId = companyId,
+            FirstName = "Alice",
+            LastName = "Anderson",
+            JobTitle = "Recruiter",
+        };
+        var existingCompany = new Company
+        {
+            Id = companyId,
+            Name = "Acme Corp",
+            Slug = "acme",
+        };
+        userRepository.GetByIdAsync(externalId, Arg.Any<CancellationToken>())
+            .Returns(existingRecruiter);
+        companyRepository.GetByIdAsync(companyId, Arg.Any<CancellationToken>())
+            .Returns(existingCompany);
+
+        var input = NewRecruiterInput("different-slug");
+
+        var result = await service.OnboardAsync(externalId, "alice@acme.test", input, CancellationToken.None);
+
+        var existing = Assert.IsType<RecruiterOnboardingResult.Existing>(result);
+        Assert.Equal(externalId, existing.RecruiterId);
+        Assert.Equal("acme", existing.Company.Slug);
+
+        await companyRepository.DidNotReceive().AddWithFirstRecruiterAsync(
+            Arg.Any<Company>(),
+            Arg.Any<RecruiterUser>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_ReturnSlugConflict_When_SlugAlreadyTaken()
+    {
+        var externalId = Guid.NewGuid();
+        userRepository.GetByIdAsync(externalId, Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+        companyRepository.SlugExistsAsync("acme", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var input = NewRecruiterInput("acme");
+
+        var result = await service.OnboardAsync(externalId, "bob@example.test", input, CancellationToken.None);
+
+        var conflict = Assert.IsType<RecruiterOnboardingResult.SlugConflict>(result);
+        Assert.Equal("acme", conflict.Slug);
+
+        await companyRepository.DidNotReceive().AddWithFirstRecruiterAsync(
+            Arg.Any<Company>(),
+            Arg.Any<RecruiterUser>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_ThrowInvalidOperation_When_UserExistsAsJobSeeker()
+    {
+        var externalId = Guid.NewGuid();
+        userRepository.GetByIdAsync(externalId, Arg.Any<CancellationToken>())
+            .Returns(new JobSeekerUser { Id = externalId, Email = "alice@example.test" });
+
+        var input = NewRecruiterInput("acme");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.OnboardAsync(externalId, "alice@example.test", input, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Should_ThrowArgumentException_When_CompanyNameIsBlank()
+    {
+        var input = new OnboardRecruiterInput(
+            CompanyName: "   ",
+            CompanySlug: "acme",
+            CompanyDescription: null,
+            CompanyWebsiteUrl: null,
+            FirstName: "Alice",
+            LastName: "Anderson",
+            JobTitle: "Recruiter");
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => service.OnboardAsync(Guid.NewGuid(), "alice@acme.test", input, CancellationToken.None));
+    }
+
+    private static OnboardRecruiterInput NewRecruiterInput(string slug) => new(
+        CompanyName: "Acme Corp",
+        CompanySlug: slug,
+        CompanyDescription: "We make anvils.",
+        CompanyWebsiteUrl: "https://acme.test",
+        FirstName: "Alice",
+        LastName: "Anderson",
+        JobTitle: "Senior Recruiter");
+}

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/AuthenticationPipelineTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/AuthenticationPipelineTests.cs
@@ -12,15 +12,9 @@ namespace Konnect.Tests.WebAPI.Authentication;
 /// <see cref="KonnectWebApplicationFactory"/>, which overrides JwtBearer to
 /// trust tokens minted by <see cref="TestJwtTokenFactory"/>.
 /// </summary>
-public class AuthenticationPipelineTests : IClassFixture<KonnectWebApplicationFactory>
+public class AuthenticationPipelineTests(KonnectWebApplicationFactory factory)
+    : IClassFixture<KonnectWebApplicationFactory>
 {
-    private readonly KonnectWebApplicationFactory factory;
-
-    public AuthenticationPipelineTests(KonnectWebApplicationFactory factory)
-    {
-        this.factory = factory;
-    }
-
     [Fact]
     public async Task Should_Return401_When_NoBearerTokenPresent()
     {

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/Fixtures/KonnectWebApplicationFactory.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/Fixtures/KonnectWebApplicationFactory.cs
@@ -1,9 +1,10 @@
+using Konnect.Infrastructure.Repositories;
+using Konnect.Infrastructure.Services.Authentication;
 using Konnect.WebAPI;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -18,7 +19,7 @@ namespace Konnect.Tests.WebAPI.Authentication.Fixtures;
 /// the bearer scheme never tries to fetch OIDC discovery from the
 /// (non-existent) Auth0 tenant.
 /// </summary>
-public sealed class KonnectWebApplicationFactory : WebApplicationFactory<WebApiEntryPoint>
+public class KonnectWebApplicationFactory : WebApplicationFactory<WebApiEntryPoint>
 {
     public TestJwtTokenFactory TokenFactory { get; } = new();
 
@@ -26,28 +27,43 @@ public sealed class KonnectWebApplicationFactory : WebApplicationFactory<WebApiE
 
     public const string EmployerAudience = "https://api.konnect.test/employer";
 
+    /// <summary>
+    /// Postgres connection string the test host should bind to. Defaults to a
+    /// dummy value that's good enough for tests which never open a real
+    /// connection (the entire auth-pipeline suite); DB-backed integration
+    /// tests assign a Testcontainers-backed connection string from
+    /// <see cref="Konnect.Tests.Infrastructure.PostgresFixture"/> before
+    /// creating a client. xUnit's <c>IClassFixture&lt;T&gt;</c> requires a
+    /// single parameterless ctor, so the override path is a settable
+    /// property rather than a ctor parameter.
+    /// </summary>
+    public string PostgresConnectionString { get; set; }
+        = "Host=127.0.0.1;Port=5432;Database=konnect_unused;Username=u;Password=p";
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Test");
 
-        builder.ConfigureAppConfiguration((_, configuration) =>
-        {
-            configuration.AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                // Real Postgres is irrelevant for auth-pipeline tests — every
-                // assertion is about the bearer scheme + middleware. The
-                // connection string just has to be present so AddDbContext
-                // does not throw at startup.
-                ["ConnectionStrings:Postgres"] =
-                    "Host=127.0.0.1;Port=5432;Database=konnect_unused;Username=u;Password=p",
-                ["Auth0:Domain"] = "konnect-test.auth0.local",
-                ["Auth0:SeekerAudience"] = SeekerAudience,
-                ["Auth0:EmployerAudience"] = EmployerAudience,
-            });
-        });
-
+        // Override every typed-options binding via Configure<T>.
+        // ConfigureTestServices runs LATE (after Program.cs has registered
+        // its bindings) and last-call-wins semantics mean these reliably
+        // substitute the test values regardless of when Program.cs reads
+        // configuration — which dodges the host-builder timing race that
+        // ConfigureAppConfiguration is subject to in minimal hosting.
         builder.ConfigureTestServices(services =>
         {
+            services.Configure<DatabaseOptions>(options =>
+            {
+                options.PostgresConnectionString = PostgresConnectionString;
+            });
+
+            services.Configure<Auth0Settings>(options =>
+            {
+                options.Domain = "konnect-test.auth0.local";
+                options.SeekerAudience = SeekerAudience;
+                options.EmployerAudience = EmployerAudience;
+            });
+
             services.AddSingleton<IPostConfigureOptions<JwtBearerOptions>>(
                 _ => new TestJwtBearerOptionsPostConfigure(TokenFactory));
         });

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/Fixtures/KonnectWebApplicationFactory.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/Fixtures/KonnectWebApplicationFactory.cs
@@ -86,15 +86,9 @@ public class KonnectWebApplicationFactory : WebApplicationFactory<WebApiEntryPoi
     /// metadata-fetch path entirely — the bearer scheme never makes an HTTP
     /// call out of the test process.
     /// </summary>
-    private sealed class TestJwtBearerOptionsPostConfigure : IPostConfigureOptions<JwtBearerOptions>
+    private sealed class TestJwtBearerOptionsPostConfigure(TestJwtTokenFactory tokenFactory)
+        : IPostConfigureOptions<JwtBearerOptions>
     {
-        private readonly TestJwtTokenFactory tokenFactory;
-
-        public TestJwtBearerOptionsPostConfigure(TestJwtTokenFactory tokenFactory)
-        {
-            this.tokenFactory = tokenFactory;
-        }
-
         public void PostConfigure(string? name, JwtBearerOptions options)
         {
             options.Authority = null;

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/Fixtures/TestJwtTokenFactory.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/Fixtures/TestJwtTokenFactory.cs
@@ -54,8 +54,5 @@ public sealed class TestJwtTokenFactory : IDisposable
         return new JsonWebTokenHandler().CreateToken(descriptor);
     }
 
-    public void Dispose()
-    {
-        rsa.Dispose();
-    }
+    public void Dispose() => rsa.Dispose();
 }

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/JobSeekerOnboardingTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/JobSeekerOnboardingTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.Infrastructure.Services.Onboarding;
+using Konnect.Tests.Infrastructure;
+using Konnect.Tests.WebAPI.Authentication.Fixtures;
+using Microsoft.EntityFrameworkCore;
+
+namespace Konnect.Tests.WebAPI.Onboarding;
+
+/// <summary>
+/// End-to-end coverage for <c>POST /api/seeker/onboard</c>: the controller
+/// + service + repository chain against a real Testcontainers Postgres.
+/// </summary>
+[Collection(DatabaseCollection.Name)]
+public sealed class JobSeekerOnboardingTests : IDisposable
+{
+    private readonly PostgresFixture postgresFixture;
+    private readonly KonnectWebApplicationFactory factory;
+
+    public JobSeekerOnboardingTests(PostgresFixture postgresFixture)
+    {
+        this.postgresFixture = postgresFixture;
+        factory = new KonnectWebApplicationFactory
+        {
+            PostgresConnectionString = postgresFixture.ConnectionString,
+        };
+    }
+
+    public void Dispose() => factory.Dispose();
+
+    [Fact]
+    public async Task Should_Return201_AndPersistJobSeeker_When_FirstOnboarding()
+    {
+        var externalId = Guid.NewGuid();
+        var client = CreateClientWithSeekerToken(externalId, "seeker@example.test");
+
+        var response = await client.PostAsJsonAsync(
+            new Uri("/api/seeker/onboard", UriKind.Relative),
+            new OnboardJobSeekerInput("Senior Engineer", "Sydney", true));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        await using var dbContext = postgresFixture.CreateDbContext();
+        var seeker = await dbContext.JobSeekers.FirstOrDefaultAsync(record => record.Id == externalId);
+        Assert.NotNull(seeker);
+        Assert.Equal("seeker@example.test", seeker.Email);
+        Assert.Equal("Senior Engineer", seeker.Headline);
+        Assert.Equal("Sydney", seeker.Location);
+        Assert.True(seeker.OpenToWork);
+        Assert.NotEqual(default, seeker.CreatedAt);
+    }
+
+    [Fact]
+    public async Task Should_Return200_When_IdempotentReplay()
+    {
+        var externalId = Guid.NewGuid();
+        var client = CreateClientWithSeekerToken(externalId, "seeker@example.test");
+
+        var first = await client.PostAsJsonAsync(
+            new Uri("/api/seeker/onboard", UriKind.Relative),
+            new OnboardJobSeekerInput("Senior Engineer", "Sydney", true));
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+
+        var second = await client.PostAsJsonAsync(
+            new Uri("/api/seeker/onboard", UriKind.Relative),
+            new OnboardJobSeekerInput("Should Not Apply", "Should Not Apply", false));
+
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+
+        await using var dbContext = postgresFixture.CreateDbContext();
+        var seeker = await dbContext.JobSeekers.FirstAsync(record => record.Id == externalId);
+        Assert.Equal("Senior Engineer", seeker.Headline);
+        Assert.True(seeker.OpenToWork);
+    }
+
+    [Fact]
+    public async Task Should_Return403_When_RecruiterTokenSentToSeekerEndpoint()
+    {
+        var externalId = Guid.NewGuid();
+        var token = factory.TokenFactory.CreateToken(
+            audience: KonnectWebApplicationFactory.EmployerAudience,
+            additionalClaims:
+            [
+                new(KonnectClaimTypes.ExternalId, externalId.ToString()),
+                new(KonnectClaimTypes.Role, JwtRoles.Recruiter),
+                new("email", "recruiter@acme.test"),
+            ]);
+
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.PostAsJsonAsync(
+            new Uri("/api/seeker/onboard", UriKind.Relative),
+            new OnboardJobSeekerInput(null, null, false));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Should_Return401_When_NoBearerToken()
+    {
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            new Uri("/api/seeker/onboard", UriKind.Relative),
+            new OnboardJobSeekerInput(null, null, false));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private HttpClient CreateClientWithSeekerToken(Guid externalId, string email)
+    {
+        var token = factory.TokenFactory.CreateToken(
+            audience: KonnectWebApplicationFactory.SeekerAudience,
+            additionalClaims:
+            [
+                new(KonnectClaimTypes.ExternalId, externalId.ToString()),
+                new(KonnectClaimTypes.Role, JwtRoles.JobSeeker),
+                new("email", email),
+            ]);
+
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+}

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/JobSeekerOnboardingTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/JobSeekerOnboardingTests.cs
@@ -13,7 +13,7 @@ namespace Konnect.Tests.WebAPI.Onboarding;
 /// End-to-end coverage for <c>POST /api/seeker/onboard</c>: the controller
 /// + service + repository chain against a real Testcontainers Postgres.
 /// </summary>
-[Collection(DatabaseCollection.Name)]
+[Collection(DatabaseTestSuite.Name)]
 public sealed class JobSeekerOnboardingTests : IDisposable
 {
     private readonly PostgresFixture postgresFixture;

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/RecruiterOnboardingTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/RecruiterOnboardingTests.cs
@@ -16,7 +16,7 @@ namespace Konnect.Tests.WebAPI.Onboarding;
 /// one transaction, is idempotent on replay, rejects audience mismatches via
 /// <c>[Authorize]</c>, and surfaces slug collisions as 409.
 /// </summary>
-[Collection(DatabaseCollection.Name)]
+[Collection(DatabaseTestSuite.Name)]
 public sealed class RecruiterOnboardingTests : IDisposable
 {
     private readonly PostgresFixture postgresFixture;

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/RecruiterOnboardingTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/RecruiterOnboardingTests.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.Infrastructure.Services.Onboarding;
+using Konnect.Tests.Infrastructure;
+using Konnect.Tests.WebAPI.Authentication.Fixtures;
+using Microsoft.EntityFrameworkCore;
+
+namespace Konnect.Tests.WebAPI.Onboarding;
+
+/// <summary>
+/// End-to-end coverage for <c>POST /api/recruiter/onboard</c>: the controller
+/// + service + repository chain against a real Testcontainers Postgres.
+/// Confirms the post-Auth0 handshake provisions a Company + RecruiterUser in
+/// one transaction, is idempotent on replay, rejects audience mismatches via
+/// <c>[Authorize]</c>, and surfaces slug collisions as 409.
+/// </summary>
+[Collection(DatabaseCollection.Name)]
+public sealed class RecruiterOnboardingTests : IDisposable
+{
+    private readonly PostgresFixture postgresFixture;
+    private readonly KonnectWebApplicationFactory factory;
+
+    public RecruiterOnboardingTests(PostgresFixture postgresFixture)
+    {
+        this.postgresFixture = postgresFixture;
+        factory = new KonnectWebApplicationFactory
+        {
+            PostgresConnectionString = postgresFixture.ConnectionString,
+        };
+    }
+
+    public void Dispose() => factory.Dispose();
+
+    [Fact]
+    public async Task Should_Return201_AndPersistCompanyAndRecruiter_When_FirstOnboarding()
+    {
+        var externalId = Guid.NewGuid();
+        var slug = NewSlug();
+        var client = CreateClientWithRecruiterToken(externalId, "alice@acme.test");
+
+        var response = await client.PostAsJsonAsync(
+            new Uri("/api/recruiter/onboard", UriKind.Relative),
+            NewRecruiterInput(slug));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        await using var dbContext = postgresFixture.CreateDbContext();
+        var recruiter = await dbContext.Recruiters
+            .Include(record => record.Company)
+            .FirstOrDefaultAsync(record => record.Id == externalId);
+
+        Assert.NotNull(recruiter);
+        Assert.Equal("alice@acme.test", recruiter.Email);
+        Assert.Equal(slug, recruiter.Company.Slug);
+        Assert.False(recruiter.Company.Verified);
+        Assert.NotEqual(default, recruiter.CreatedAt);
+        Assert.NotEqual(default, recruiter.Company.CreatedAt);
+    }
+
+    [Fact]
+    public async Task Should_Return200_When_IdempotentReplay()
+    {
+        var externalId = Guid.NewGuid();
+        var slug = NewSlug();
+        var client = CreateClientWithRecruiterToken(externalId, "alice@acme.test");
+
+        var first = await client.PostAsJsonAsync(
+            new Uri("/api/recruiter/onboard", UriKind.Relative),
+            NewRecruiterInput(slug));
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+
+        var second = await client.PostAsJsonAsync(
+            new Uri("/api/recruiter/onboard", UriKind.Relative),
+            NewRecruiterInput(NewSlug(), companyName: "Should Not Apply"));
+
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+
+        await using var dbContext = postgresFixture.CreateDbContext();
+        var company = await dbContext.Companies.FirstAsync(record => record.Slug == slug);
+        Assert.Equal("Acme Corp", company.Name);
+
+        var recruiterRowCount = await dbContext.Recruiters
+            .Where(record => record.Id == externalId)
+            .CountAsync();
+        Assert.Equal(1, recruiterRowCount);
+    }
+
+    [Fact]
+    public async Task Should_Return409_When_SlugAlreadyOwnedByDifferentRecruiter()
+    {
+        var slug = NewSlug();
+
+        var firstClient = CreateClientWithRecruiterToken(Guid.NewGuid(), "alice@acme.test");
+        var firstOnboard = await firstClient.PostAsJsonAsync(
+            new Uri("/api/recruiter/onboard", UriKind.Relative),
+            NewRecruiterInput(slug));
+        Assert.Equal(HttpStatusCode.Created, firstOnboard.StatusCode);
+
+        var secondClient = CreateClientWithRecruiterToken(Guid.NewGuid(), "bob@acme-rival.test");
+        var collision = await secondClient.PostAsJsonAsync(
+            new Uri("/api/recruiter/onboard", UriKind.Relative),
+            NewRecruiterInput(slug));
+
+        Assert.Equal(HttpStatusCode.Conflict, collision.StatusCode);
+    }
+
+    [Fact]
+    public async Task Should_Return403_When_SeekerTokenSentToRecruiterEndpoint()
+    {
+        var externalId = Guid.NewGuid();
+        var token = factory.TokenFactory.CreateToken(
+            audience: KonnectWebApplicationFactory.SeekerAudience,
+            additionalClaims:
+            [
+                new(KonnectClaimTypes.ExternalId, externalId.ToString()),
+                new(KonnectClaimTypes.Role, JwtRoles.JobSeeker),
+                new("email", "seeker@example.test"),
+            ]);
+
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.PostAsJsonAsync(
+            new Uri("/api/recruiter/onboard", UriKind.Relative),
+            NewRecruiterInput(NewSlug()));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Should_Return401_When_NoBearerToken()
+    {
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            new Uri("/api/recruiter/onboard", UriKind.Relative),
+            NewRecruiterInput(NewSlug()));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private HttpClient CreateClientWithRecruiterToken(Guid externalId, string email)
+    {
+        var token = factory.TokenFactory.CreateToken(
+            audience: KonnectWebApplicationFactory.EmployerAudience,
+            additionalClaims:
+            [
+                new(KonnectClaimTypes.ExternalId, externalId.ToString()),
+                new(KonnectClaimTypes.Role, JwtRoles.Recruiter),
+                new("email", email),
+            ]);
+
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private static OnboardRecruiterInput NewRecruiterInput(string slug, string companyName = "Acme Corp")
+        => new(
+            CompanyName: companyName,
+            CompanySlug: slug,
+            CompanyDescription: "We make anvils.",
+            CompanyWebsiteUrl: "https://acme.test",
+            FirstName: "Alice",
+            LastName: "Anderson",
+            JobTitle: "Senior Recruiter");
+
+    private static string NewSlug() => $"acme-{Guid.NewGuid():N}";
+}

--- a/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/JobSeekerOnboardingController.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/JobSeekerOnboardingController.cs
@@ -16,15 +16,8 @@ namespace Konnect.WebAPI.Controllers.Onboarding;
 [ApiController]
 [Route("api/seeker/onboard")]
 [Authorize(Roles = JwtRoles.JobSeeker)]
-public sealed class JobSeekerOnboardingController : ControllerBase
+public sealed class JobSeekerOnboardingController(IJobSeekerOnboardingService onboardingService) : ControllerBase
 {
-    private readonly IJobSeekerOnboardingService onboardingService;
-
-    public JobSeekerOnboardingController(IJobSeekerOnboardingService onboardingService)
-    {
-        this.onboardingService = onboardingService;
-    }
-
     [HttpPost]
     public async Task<IActionResult> Onboard(
         [FromBody] OnboardJobSeekerInput input,

--- a/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/JobSeekerOnboardingController.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/JobSeekerOnboardingController.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.Infrastructure.Services.Onboarding;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Konnect.WebAPI.Controllers.Onboarding;
+
+/// <summary>
+/// Post-Auth0 handshake for job seekers. The Auth0 SPA hits this endpoint
+/// once after sign-up to provision the <c>JobSeekerUser</c> row; subsequent
+/// calls are idempotent and return the existing seeker without writes.
+/// Identity comes from the JWT, never from the request body.
+/// </summary>
+[ApiController]
+[Route("api/seeker/onboard")]
+[Authorize(Roles = JwtRoles.JobSeeker)]
+public sealed class JobSeekerOnboardingController : ControllerBase
+{
+    private readonly IJobSeekerOnboardingService onboardingService;
+
+    public JobSeekerOnboardingController(IJobSeekerOnboardingService onboardingService)
+    {
+        this.onboardingService = onboardingService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Onboard(
+        [FromBody] OnboardJobSeekerInput input,
+        CancellationToken cancellationToken)
+    {
+        var externalId = ReadExternalId();
+        var email = ReadEmail();
+
+        var result = await onboardingService.OnboardAsync(externalId, email, input, cancellationToken);
+
+        return result switch
+        {
+            JobSeekerOnboardingResult.Created created => StatusCode(
+                StatusCodes.Status201Created,
+                ToResponse(created.JobSeeker)),
+            JobSeekerOnboardingResult.Existing existing => Ok(
+                ToResponse(existing.JobSeeker)),
+            _ => throw new InvalidOperationException($"Unhandled onboarding result: {result.GetType().Name}"),
+        };
+    }
+
+    private Guid ReadExternalId()
+    {
+        var raw = User.FindFirst(KonnectClaimTypes.ExternalId)?.Value;
+        return Guid.TryParse(raw, out var externalId)
+            ? externalId
+            : throw new InvalidOperationException(
+                $"Authenticated request reached seeker onboarding without a valid {KonnectClaimTypes.ExternalId} claim.");
+    }
+
+    private string ReadEmail()
+        => User.FindFirst("email")?.Value
+            ?? throw new InvalidOperationException(
+                "Authenticated request reached seeker onboarding without an email claim.");
+
+    private static JobSeekerOnboardingResponse ToResponse(JobSeekerUser seeker)
+        => new(
+            seeker.Id,
+            seeker.Email,
+            seeker.Headline,
+            seeker.Location,
+            seeker.OpenToWork,
+            seeker.CreatedAt.ToString("O", CultureInfo.InvariantCulture));
+}
+
+public sealed record JobSeekerOnboardingResponse(
+    Guid JobSeekerId,
+    string Email,
+    string Headline,
+    string Location,
+    bool OpenToWork,
+    string CreatedAt);

--- a/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/RecruiterOnboardingController.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/RecruiterOnboardingController.cs
@@ -1,0 +1,93 @@
+using System.Globalization;
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.Infrastructure.Services.Onboarding;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Konnect.WebAPI.Controllers.Onboarding;
+
+/// <summary>
+/// Post-Auth0 handshake for recruiters. The Auth0 SPA hits this endpoint
+/// once after sign-up to provision the <c>RecruiterUser</c> + owning
+/// <c>Company</c> rows; subsequent calls (e.g. SPA replays after a network
+/// hiccup) are idempotent and return the existing pair without writes.
+/// Identity always comes from the JWT — never from the request body — so a
+/// recruiter cannot onboard another user.
+/// </summary>
+[ApiController]
+[Route("api/recruiter/onboard")]
+[Authorize(Roles = JwtRoles.Recruiter)]
+public sealed class RecruiterOnboardingController : ControllerBase
+{
+    private readonly IRecruiterOnboardingService onboardingService;
+
+    public RecruiterOnboardingController(IRecruiterOnboardingService onboardingService)
+    {
+        this.onboardingService = onboardingService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Onboard(
+        [FromBody] OnboardRecruiterInput input,
+        CancellationToken cancellationToken)
+    {
+        var externalId = ReadExternalId();
+        var email = ReadEmail();
+
+        var result = await onboardingService.OnboardAsync(externalId, email, input, cancellationToken);
+
+        return result switch
+        {
+            RecruiterOnboardingResult.Created created => StatusCode(
+                StatusCodes.Status201Created,
+                ToResponse(created.RecruiterId, created.Company)),
+            RecruiterOnboardingResult.Existing existing => Ok(
+                ToResponse(existing.RecruiterId, existing.Company)),
+            RecruiterOnboardingResult.SlugConflict conflict => Conflict(new
+            {
+                error = "slug_conflict",
+                slug = conflict.Slug,
+                message = $"Company slug '{conflict.Slug}' is already taken.",
+            }),
+            _ => throw new InvalidOperationException($"Unhandled onboarding result: {result.GetType().Name}"),
+        };
+    }
+
+    private Guid ReadExternalId()
+    {
+        var raw = User.FindFirst(KonnectClaimTypes.ExternalId)?.Value;
+        return Guid.TryParse(raw, out var externalId)
+            ? externalId
+            : throw new InvalidOperationException(
+                $"Authenticated request reached recruiter onboarding without a valid {KonnectClaimTypes.ExternalId} claim.");
+    }
+
+    private string ReadEmail()
+        => User.FindFirst("email")?.Value
+            ?? throw new InvalidOperationException(
+                "Authenticated request reached recruiter onboarding without an email claim.");
+
+    private static RecruiterOnboardingResponse ToResponse(Guid recruiterId, Company company)
+        => new(
+            recruiterId,
+            new OnboardingCompanyResponse(
+                company.Id,
+                company.Name,
+                company.Slug,
+                company.Description,
+                company.WebsiteUrl,
+                company.Verified,
+                company.CreatedAt.ToString("O", CultureInfo.InvariantCulture)));
+}
+
+public sealed record RecruiterOnboardingResponse(Guid RecruiterId, OnboardingCompanyResponse Company);
+
+public sealed record OnboardingCompanyResponse(
+    Guid Id,
+    string Name,
+    string Slug,
+    string? Description,
+    string? WebsiteUrl,
+    bool Verified,
+    string CreatedAt);

--- a/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/RecruiterOnboardingController.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/RecruiterOnboardingController.cs
@@ -18,15 +18,8 @@ namespace Konnect.WebAPI.Controllers.Onboarding;
 [ApiController]
 [Route("api/recruiter/onboard")]
 [Authorize(Roles = JwtRoles.Recruiter)]
-public sealed class RecruiterOnboardingController : ControllerBase
+public sealed class RecruiterOnboardingController(IRecruiterOnboardingService onboardingService) : ControllerBase
 {
-    private readonly IRecruiterOnboardingService onboardingService;
-
-    public RecruiterOnboardingController(IRecruiterOnboardingService onboardingService)
-    {
-        this.onboardingService = onboardingService;
-    }
-
     [HttpPost]
     public async Task<IActionResult> Onboard(
         [FromBody] OnboardRecruiterInput input,

--- a/Konnect.Platform/Konnect.WebAPI/Program.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Program.cs
@@ -1,6 +1,8 @@
 using Konnect.GraphQL;
+using Konnect.Infrastructure.Repositories;
 using Konnect.Infrastructure.Services.Authentication;
 using Konnect.Repositories;
+using Konnect.Services;
 using Konnect.WebAPI.Middleware;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Options;
@@ -12,10 +14,23 @@ builder.Services.AddControllers();
 builder.Services.AddOpenApi();
 builder.Services.AddKonnectGraphQL();
 
-var postgresConnectionString = builder.Configuration.GetConnectionString("Postgres")
-    ?? throw new InvalidOperationException("Connection string 'Postgres' is required.");
+// Strongly-typed options for every infrastructure dependency. Bound lazily
+// so the validators run when the options are first resolved, and so test
+// overrides via services.Configure<T> apply cleanly.
+builder.Services
+    .AddOptions<DatabaseOptions>()
+    .Bind(builder.Configuration.GetSection(DatabaseOptions.SectionName))
+    .Validate(
+        options => !string.IsNullOrWhiteSpace(options.PostgresConnectionString),
+        "Database:PostgresConnectionString is required.");
 
-builder.Services.AddKonnectRepositories(postgresConnectionString);
+if (!builder.Environment.IsEnvironment("Test"))
+{
+    builder.Services.AddOptions<DatabaseOptions>().ValidateOnStart();
+}
+
+builder.Services.AddKonnectRepositories();
+builder.Services.AddKonnectServices();
 
 // Bind the Auth0 section lazily. Eager reads (e.g. .Get<Auth0Settings>())
 // would happen before WebApplicationFactory's in-memory configuration

--- a/Konnect.Platform/Konnect.WebAPI/appsettings.Development.json
+++ b/Konnect.Platform/Konnect.WebAPI/appsettings.Development.json
@@ -5,8 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ConnectionStrings": {
-    "Postgres": "Host=127.0.0.1;Port=5432;Database=konnect;Username=konnect;Password=konnect_dev_only;Include Error Detail=true"
+  "Database": {
+    "PostgresConnectionString": "Host=127.0.0.1;Port=5432;Database=konnect;Username=konnect;Password=konnect_dev_only;Include Error Detail=true"
   },
   "Auth0": {
     "Domain": "dev-7tezygfwayj84twt.us.auth0.com",

--- a/Konnect.Platform/Konnect.WebAPI/appsettings.json
+++ b/Konnect.Platform/Konnect.WebAPI/appsettings.json
@@ -6,8 +6,8 @@
     }
   },
   "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "Postgres": ""
+  "Database": {
+    "PostgresConnectionString": ""
   },
   "Auth0": {
     "Domain": "",

--- a/wikis/Architecture.md
+++ b/wikis/Architecture.md
@@ -82,10 +82,18 @@ Per-csproj files inherit everything from the directory props — they typically 
 builder.Services.AddControllers();      // REST surface
 builder.Services.AddOpenApi();          // /openapi/v1.json in development
 builder.Services.AddKonnectGraphQL();   // /graphql + HotChocolate pipeline
-builder.Services.AddKonnectRepositories(...);
 
-// Auth0 OIDC — JwtBearer scheme accepts tokens for both seeker + employer audiences
-builder.Services.AddOptions<Auth0Settings>().Bind(...);
+// Strongly-typed options for every infrastructure dependency. Each
+// dependency owns its own Options record (DatabaseOptions, Auth0Settings,
+// future RedisCacheOptions / MinioOptions / ...) bound from its own config
+// section — production code never reads loose IConfiguration strings.
+builder.Services.AddOptions<DatabaseOptions>().Bind(...).Validate(...);
+builder.Services.AddOptions<Auth0Settings>().Bind(...).Validate(...);
+
+builder.Services.AddKonnectRepositories();   // resolves DatabaseOptions lazily
+builder.Services.AddKonnectServices();       // onboarding + future services
+
+// Auth0 OIDC — JwtBearer scheme accepts tokens for both seeker + recruiter audiences
 builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme).Configure<IOptions<Auth0Settings>>(...);
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer();
 builder.Services.AddAuthorization();
@@ -105,11 +113,15 @@ Today, the routes that respond are:
 | Route | What it returns | Auth |
 |---|---|---|
 | `GET /api/me` | The authenticated caller's `external_id`, `role`, and `email`, distilled from JWT claims. Useful as an auth smoke test from the SPAs. | `[Authorize]` |
+| `POST /api/recruiter/onboard` | Provisions the `Company` + first `RecruiterUser` row after the SPA's first Auth0 sign-in. Idempotent on the JWT `external_id` claim. See [Onboarding](api/Onboarding). | `[Authorize(Roles = "Recruiter")]` |
+| `POST /api/seeker/onboard` | Provisions the `JobSeekerUser` row after the SPA's first Auth0 sign-in. Idempotent. | `[Authorize(Roles = "JobSeeker")]` |
 | `POST /graphql` | The single query `{ healthcheck }` — see [`Konnect.GraphQL/Schema/Query.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.GraphQL/Schema/Query.cs) | anonymous |
 | `GET /graphql` *(dev only)* | Banana Cake Pop / Nitro UI | anonymous |
 | `GET /openapi/v1.json` *(dev only)* | OpenAPI document | anonymous |
 
-Authentication is delegated to **Auth0** — Konnect never stores passwords, never issues JWTs, and holds no refresh-token state. The full picture (tenant setup, the two Auth0 Actions, the audience-split, the operational note about the Pre-User-Registration Action) lives on the [Authentication — Auth0](api/Authentication-Auth0) page.
+Authentication is delegated to **Auth0** — Konnect never stores passwords, never issues JWTs, and holds no refresh-token state. The full picture (tenant setup, the two Auth0 Actions, the audience-split, the operational note about the Pre-User-Registration Action) lives on the [Authentication — Auth0](api/Authentication-Auth0) page. Identity-to-domain handshake (the post-Auth0 onboarding step that creates the `JobSeekerUser` / `RecruiterUser` + `Company` rows) is documented on the [Onboarding](api/Onboarding) page.
+
+Audit timestamps (`created_at`, `updated_at`) are owned by Postgres: a column default plus a `BEFORE UPDATE` trigger calling a shared `set_updated_at()` function. Application services never assign these — keeps the application clock and DB clock from skewing, and the schema stays correct even if a non-EF caller (psql, ETL) writes rows. See [`Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.cs).
 
 The convention: each cross-cutting concern is registered through a single extension method that lives in the project that owns it. `AddKonnectGraphQL()` lives in [`Konnect.GraphQL/GraphQLServiceCollectionExtensions.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.GraphQL/GraphQLServiceCollectionExtensions.cs). Future concerns follow the same shape — `Program.cs` stays a short list of capabilities, not a wiring tangle.
 

--- a/wikis/api/Onboarding.md
+++ b/wikis/api/Onboarding.md
@@ -1,0 +1,133 @@
+# Onboarding
+
+Auth0 owns identity for Konnect — the two SPAs (seeker + recruiter) sign users up via Auth0 Universal Login, never against our API. After Auth0 issues the first access token, the SPA hits **one** of these onboarding endpoints to provision the corresponding domain row in our Postgres. Without that handshake, an Auth0-authenticated user has a valid JWT but no `JobSeekerUser` / `RecruiterUser` row, so every recruiter- or seeker-scoped feature dereferences nothing.
+
+Both endpoints are **idempotent on the JWT `external_id` claim**. The SPA is free to retry on network hiccups; the second call returns the same body it returned the first time.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    participant SPA as SPA (seeker / recruiter)
+    participant Auth0 as Auth0 Universal Login
+    participant API as Konnect.WebAPI
+    participant DB as Postgres
+
+    SPA->>Auth0: redirect to /authorize
+    Auth0-->>SPA: access_token (with external_id, role, email claims)
+    SPA->>API: POST /api/{seeker|recruiter}/onboard<br/>Authorization: Bearer <access_token>
+    API->>DB: SELECT users WHERE id = external_id
+    alt No row yet
+        API->>DB: INSERT (one transaction for recruiter)
+        API-->>SPA: 201 Created + body
+    else Row already exists
+        API-->>SPA: 200 OK + body (idempotent)
+    end
+```
+
+## Recruiter — `POST /api/recruiter/onboard`
+
+Atomically creates one `Company` and one `RecruiterUser` row (the one matching the JWT `external_id`). The recruiter's identity (`Id`, `Email`) comes from the JWT — never from the request body — so a recruiter cannot onboard another user.
+
+**Auth:** `[Authorize(Roles = "Recruiter")]`. Seeker tokens get **403**.
+
+### Request
+
+```http
+POST /api/recruiter/onboard
+Authorization: Bearer <recruiter access_token>
+Content-Type: application/json
+
+{
+  "companyName": "Acme Corp",
+  "companySlug": "acme",
+  "companyDescription": "We make anvils.",
+  "companyWebsiteUrl": "https://acme.test",
+  "firstName": "Alice",
+  "lastName": "Anderson",
+  "jobTitle": "Senior Recruiter"
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `companyName` | yes | max 200 |
+| `companySlug` | yes | max 120, **unique across all companies** |
+| `companyDescription` | no | max 4000 |
+| `companyWebsiteUrl` | no | max 500 |
+| `firstName` / `lastName` | yes | max 80 each |
+| `jobTitle` | yes | max 120 |
+
+### Responses
+
+| Status | When | Body |
+|---|---|---|
+| `201 Created` | First onboarding for this `external_id`. Company + Recruiter rows created in one transaction. | `RecruiterOnboardingResponse` |
+| `200 OK` | This `external_id` already has a `RecruiterUser` row. Body returned unchanged from the first call — request body ignored. | `RecruiterOnboardingResponse` |
+| `409 Conflict` | `companySlug` is already owned by a different recruiter. | `{ "error": "slug_conflict", "slug": "...", "message": "..." }` |
+| `403 Forbidden` | The Bearer token's role is not `Recruiter` (e.g. a seeker token). | — |
+| `401 Unauthorized` | No / invalid Bearer token. | — |
+
+```jsonc
+// 201 / 200 body
+{
+  "recruiterId": "...",
+  "company": {
+    "id": "...",
+    "name": "Acme Corp",
+    "slug": "acme",
+    "description": "We make anvils.",
+    "websiteUrl": "https://acme.test",
+    "verified": false,
+    "createdAt": "2026-05-08T12:34:56.0000000+00:00"
+  }
+}
+```
+
+`createdAt` is stamped by Postgres (`DEFAULT CURRENT_TIMESTAMP`); the application never sets it. Same trigger keeps `updated_at` fresh on every row UPDATE.
+
+## Job seeker — `POST /api/seeker/onboard`
+
+Creates one `JobSeekerUser` row. No transaction (single insert).
+
+**Auth:** `[Authorize(Roles = "JobSeeker")]`. Recruiter tokens get **403**.
+
+### Request
+
+```http
+POST /api/seeker/onboard
+Authorization: Bearer <seeker access_token>
+Content-Type: application/json
+
+{
+  "headline": "Senior Engineer",
+  "location": "Sydney",
+  "openToWork": true
+}
+```
+
+All three fields are optional. Empty strings or `null` are stored as empty strings (matches the EF default-value config on the entity).
+
+### Responses
+
+| Status | When |
+|---|---|
+| `201 Created` | First onboarding for this `external_id`. |
+| `200 OK` | Idempotent replay — `JobSeekerUser` row already exists. |
+| `403 Forbidden` | Recruiter token sent. |
+| `401 Unauthorized` | No / invalid Bearer token. |
+
+## Idempotency contract
+
+Both endpoints look up `users.id = JWT.external_id` first. If a row exists for the *correct* audience subtype, return it as-is with `200`. If a row exists for the *wrong* subtype (e.g. JWT says `Recruiter` but DB has a `JobSeekerUser`), the service throws — Auth0's pre-registration action enforces a single audience per identity, so this state should be impossible and is treated as an upstream bug.
+
+The SPA can retry on any network hiccup. It can also call onboard on every app boot if it wants to be defensive — the second-call cost is one indexed `SELECT` plus a `200`.
+
+## Where the code lives
+
+- Controllers: [`Konnect.WebAPI/Controllers/Onboarding/`](https://github.com/win-son-dev/konnect-server/tree/main/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding)
+- Services: [`Konnect.Services/Onboarding/`](https://github.com/win-son-dev/konnect-server/tree/main/Konnect.Platform/Konnect.Services/Onboarding)
+- Service contracts + DTOs: [`Konnect.Infrastructure/Services/Onboarding/`](https://github.com/win-son-dev/konnect-server/tree/main/Konnect.Platform/Konnect.Infrastructure/Services/Onboarding)
+- Repository contracts: [`IUserRepository`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.Infrastructure/Repositories/IUserRepository.cs), [`ICompanyRepository`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.Infrastructure/Repositories/ICompanyRepository.cs)
+- DB-managed timestamps migration: [`20260508121429_AddDbManagedTimestamps`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.cs)
+- Tests: [`Konnect.Tests/WebAPI/Onboarding/`](https://github.com/win-son-dev/konnect-server/tree/main/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding) (integration), [`Konnect.Tests/Services/Onboarding/`](https://github.com/win-son-dev/konnect-server/tree/main/Konnect.Platform/Konnect.Tests/Services/Onboarding) (unit)


### PR DESCRIPTION
Closes #51. Unblocks #24, #25, #26.

## Summary

- `POST /api/recruiter/onboard` — atomically creates `Company` + first `RecruiterUser` row, idempotent on the JWT `external_id` claim.
- `POST /api/seeker/onboard` — creates the `JobSeekerUser` row, same idempotency contract.
- Closes the gap that the Auth0 pivot (#46/#48) left when #22/#23 were dropped — Auth0 owns identity but until now nothing created the corresponding domain rows in Postgres, blocking every recruiter/seeker-scoped feature.

## Side changes paid off in the same PR

**Typed options for infrastructure config.** `DatabaseOptions` joins `Auth0Settings` as a typed record bound from its own config section. Production code never reads loose `IConfiguration` strings inline; tests override via `services.Configure<T>(...)` which dodges the host-builder timing race that `ConfigureAppConfiguration` is subject to in minimal hosting. Future Redis / MinIO / Auth0-management options follow the same pattern.

**Audit timestamps owned by Postgres.** `created_at` and `updated_at` on `users` and `companies` get `DEFAULT CURRENT_TIMESTAMP` plus a shared `set_updated_at()` PL/pgSQL function fired by `BEFORE UPDATE` triggers. Application services no longer assign these — removes the `TimeProvider` dependency, removes app/DB clock skew, and means the schema stays correct even if a non-EF caller (psql, ETL) writes rows. Migration `20260508121429_AddDbManagedTimestamps` lands the column defaults + trigger SQL via `migrationBuilder.Sql(...)`.

**Phase-1 scope decision baked in.** No `IsCompanyAdmin` column, no `CompanyAdmin` role / policy. Phase 1 has exactly one recruiter per company, so the admin-vs-member distinction gates nothing real today — deferred to whenever multi-recruiter teams ship. The issue text in #24 / #26 mentioning CompanyAdmin should be treated as stale.

## Test plan

- [x] `dotnet build` — green (0 errors, 0 warnings outside pre-existing PostgresFixture warnings)
- [x] `dotnet test` — **49/49 passing** (was 31 before; +18 new: 9 unit, 9 integration)
- [x] Unit tests via NSubstitute pin: idempotency, slug-conflict short-circuit, audience-mismatch detection, validation
- [x] Integration tests via `WebApplicationFactory` + Testcontainers Postgres pin: 201 on first onboard, 200 on idempotent replay, 409 on slug collision (different `external_id`), 403 on cross-role token, 401 on no token — both endpoints
- [x] DB-managed timestamps verified end-to-end (integration tests assert `CreatedAt != default` after onboard; the Postgres clock fills it)
- [x] Architecture test still green (Infrastructure has no concrete implementations; `DatabaseOptions` and `Auth0Settings` are records and pass the existing filter)

## Documentation

- New: `wikis/api/Onboarding.md` — sequence diagram, request/response shapes for both endpoints, idempotency contract, file map.
- Updated: `wikis/Architecture.md` — added the two onboarding routes to the routes table, updated the `Program.cs` snippet to reflect typed options + `AddKonnectServices()`, added a paragraph on DB-managed audit timestamps.

## Branch & PR

Branch `dev/51` · plain merge commit · do not squash (PR convention in this repo is one commit per PR, merge with the PR-merge button).