### PR TITLE
feature(companies): Company GraphQL reads + recruiter REST update (#24)

### DIFF
--- a/Konnect.Platform/Directory.Packages.props
+++ b/Konnect.Platform/Directory.Packages.props
@@ -13,6 +13,7 @@
 
   <ItemGroup Label="GraphQL (HotChocolate)">
     <PackageVersion Include="HotChocolate.AspNetCore" Version="16.0.0" />
+    <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="16.0.0" />
     <PackageVersion Include="HotChocolate.Types" Version="16.0.0" />
   </ItemGroup>
 

--- a/Konnect.Platform/Konnect.GraphQL/Extensions/GraphQLServiceCollectionExtensions.cs
+++ b/Konnect.Platform/Konnect.GraphQL/Extensions/GraphQLServiceCollectionExtensions.cs
@@ -1,7 +1,8 @@
 using Konnect.GraphQL.Schema;
+using Konnect.GraphQL.Schema.Companies;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Konnect.GraphQL;
+namespace Konnect.GraphQL.Extensions;
 
 public static class GraphQLServiceCollectionExtensions
 {
@@ -9,7 +10,11 @@ public static class GraphQLServiceCollectionExtensions
     {
         services
             .AddGraphQLServer()
-            .AddQueryType<Query>();
+            .AddAuthorization()
+            .AddQueryType<Query>()
+            .AddType<CompanyType>()
+            .AddTypeExtension<CompanyQueries>()
+            .AddTypeExtension<RecruiterCompanyQueries>();
 
         return services;
     }

--- a/Konnect.Platform/Konnect.GraphQL/Konnect.GraphQL.csproj
+++ b/Konnect.Platform/Konnect.GraphQL/Konnect.GraphQL.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="HotChocolate.AspNetCore" />
+    <PackageReference Include="HotChocolate.AspNetCore.Authorization" />
     <PackageReference Include="HotChocolate.Types" />
   </ItemGroup>
 

--- a/Konnect.Platform/Konnect.GraphQL/Schema/Companies/CompanyQueries.cs
+++ b/Konnect.Platform/Konnect.GraphQL/Schema/Companies/CompanyQueries.cs
@@ -1,0 +1,17 @@
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Services.Companies.Queries;
+
+namespace Konnect.GraphQL.Schema.Companies;
+
+/// <summary>
+/// Public Company query field — adds <c>Query.company(slug)</c> to the
+/// schema via HotChocolate's type-extension mechanism. Services are
+/// constructor-injected so the resolver method only carries GraphQL field
+/// arguments + the cancellation token.
+/// </summary>
+[ExtendObjectType(typeof(Query))]
+public sealed class CompanyQueries(ICompanyQueryService companyQueryService)
+{
+    public Task<Company?> Company(string slug, CancellationToken cancellationToken)
+        => companyQueryService.GetBySlugAsync(slug, cancellationToken);
+}

--- a/Konnect.Platform/Konnect.GraphQL/Schema/Companies/CompanyType.cs
+++ b/Konnect.Platform/Konnect.GraphQL/Schema/Companies/CompanyType.cs
@@ -1,0 +1,21 @@
+using Konnect.Infrastructure.Entities;
+
+namespace Konnect.GraphQL.Schema.Companies;
+
+/// <summary>
+/// Public GraphQL representation of <see cref="Company"/>. Navigation
+/// collections (<c>Recruiters</c>, <c>JobPostings</c>) are intentionally
+/// hidden: the public schema exposes companies for browse/profile only, and
+/// recruiter rosters are never world-readable. Job postings will be exposed
+/// via a separate top-level field once Issue #25 lands rather than as a
+/// nested projection here.
+/// </summary>
+public sealed class CompanyType : ObjectType<Company>
+{
+    protected override void Configure(IObjectTypeDescriptor<Company> descriptor)
+    {
+        descriptor.Description("An employer organisation that posts jobs.");
+        descriptor.Ignore(company => company.Recruiters);
+        descriptor.Ignore(company => company.JobPostings);
+    }
+}

--- a/Konnect.Platform/Konnect.GraphQL/Schema/Companies/RecruiterCompanyQueries.cs
+++ b/Konnect.Platform/Konnect.GraphQL/Schema/Companies/RecruiterCompanyQueries.cs
@@ -1,0 +1,23 @@
+using System.Security.Claims;
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.Infrastructure.Services.Companies.Queries;
+
+namespace Konnect.GraphQL.Schema.Companies;
+
+/// <summary>
+/// Recruiter-scoped Company query — adds <c>RecruiterQueries.company</c> to
+/// the schema via HotChocolate's type-extension mechanism. The target
+/// company is derived from the recruiter's JWT external_id, so a recruiter
+/// can only ever read their own company through this field.
+/// </summary>
+[ExtendObjectType(typeof(RecruiterQueries))]
+public sealed class RecruiterCompanyQueries(ICompanyQueryService companyQueryService)
+{
+    public Task<Company> Company(
+        ClaimsPrincipal claimsPrincipal,
+        CancellationToken cancellationToken)
+        => companyQueryService.GetByRecruiterIdAsync(
+            claimsPrincipal.GetExternalId(),
+            cancellationToken);
+}

--- a/Konnect.Platform/Konnect.GraphQL/Schema/Query.cs
+++ b/Konnect.Platform/Konnect.GraphQL/Schema/Query.cs
@@ -1,6 +1,21 @@
+using HotChocolate.Authorization;
+using Konnect.Infrastructure.Services.Authentication;
+
 namespace Konnect.GraphQL.Schema;
 
-public partial class Query
+/// <summary>
+/// Root <c>Query</c> type. Concrete read fields live on per-feature
+/// <c>[ExtendObjectType(typeof(Query))]</c> classes (see e.g.
+/// <c>CompanyQueries</c>) so each feature owns one resolver class with its
+/// own constructor-injected services. The recruiter-scoped subtree is
+/// reachable through the <see cref="Recruiter"/> wrapper, which is gated
+/// once at this level so every nested field is gated by virtue of being
+/// reachable.
+/// </summary>
+public class Query
 {
     public string Healthcheck() => "ok";
+
+    [Authorize(Roles = [JwtRoles.Recruiter])]
+    public RecruiterQueries Recruiter() => new();
 }

--- a/Konnect.Platform/Konnect.GraphQL/Schema/RecruiterQueries.cs
+++ b/Konnect.Platform/Konnect.GraphQL/Schema/RecruiterQueries.cs
@@ -1,0 +1,14 @@
+namespace Konnect.GraphQL.Schema;
+
+/// <summary>
+/// Wrapper type for recruiter-scoped GraphQL query fields. Mounted under
+/// <c>Query.recruiter</c>; the parent field carries
+/// <c>[Authorize(Roles = JwtRoles.Recruiter)]</c>, so every nested field is
+/// gated by virtue of being reachable. Concrete fields live on per-feature
+/// <c>[ExtendObjectType(typeof(RecruiterQueries))]</c> classes (see e.g.
+/// <c>RecruiterCompanyQueries</c>) — each owns its own constructor-injected
+/// services.
+/// </summary>
+public class RecruiterQueries
+{
+}

--- a/Konnect.Platform/Konnect.Infrastructure/Contracts/Companies/UpdateCompanyInput.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Contracts/Companies/UpdateCompanyInput.cs
@@ -1,0 +1,13 @@
+namespace Konnect.Infrastructure.Contracts.Companies;
+
+/// <summary>
+/// Recruiter-supplied payload for editing the company profile they own.
+/// Slug is intentionally NOT updatable here — renaming a company's public
+/// URL slug needs its own flow with uniqueness validation and a redirect
+/// from the old slug, none of which Phase 1 ships. <c>Verified</c> is also
+/// off-limits to recruiter self-edits — it's an admin/moderation flag.
+/// </summary>
+public sealed record UpdateCompanyInput(
+    string Name,
+    string? Description,
+    string? WebsiteUrl);

--- a/Konnect.Platform/Konnect.Infrastructure/Repositories/ICompanyRepository.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Repositories/ICompanyRepository.cs
@@ -28,4 +28,13 @@ public interface ICompanyRepository
         Company company,
         RecruiterUser firstRecruiter,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Persists modifications to an existing <paramref name="company"/>.
+    /// EF's change tracker drives the SQL: a tracked entity emits an UPDATE
+    /// only for the dirty columns; a detached entity is treated as a full
+    /// replace. <c>updated_at</c> is refreshed by the Postgres
+    /// <c>set_updated_at</c> trigger — the application never assigns it.
+    /// </summary>
+    Task UpdateAsync(Company company, CancellationToken cancellationToken);
 }

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Authentication/ClaimsPrincipalExtensions.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Authentication/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,24 @@
+using System.Security.Claims;
+
+namespace Konnect.Infrastructure.Services.Authentication;
+
+/// <summary>
+/// Read accessors for Konnect's namespaced JWT claims. Lives next to
+/// <see cref="KonnectClaimTypes"/> and <see cref="JwtRoles"/> so the
+/// Authentication folder is the single source of truth for any code that
+/// reads the access token. Authenticated requests always pass through
+/// <c>KonnectAuthenticationMiddleware</c> first, which validates the claim
+/// shape and 401s on anything malformed — so callers here trust that an
+/// authenticated principal carries a parseable claim and these methods
+/// never throw on missing/bad input. Anything unexpected falls through as
+/// <see cref="Guid.Empty"/>, surfacing as a normal "not found" downstream
+/// rather than a hot exception an attacker could try to spam.
+/// </summary>
+public static class ClaimsPrincipalExtensions
+{
+    public static Guid GetExternalId(this ClaimsPrincipal principal)
+    {
+        var raw = principal.FindFirst(KonnectClaimTypes.ExternalId)?.Value;
+        return Guid.TryParse(raw, out var externalId) ? externalId : Guid.Empty;
+    }
+}

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Companies/Commands/ICompanyCommandService.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Companies/Commands/ICompanyCommandService.cs
@@ -1,0 +1,25 @@
+using Konnect.Infrastructure.Contracts.Companies;
+using Konnect.Infrastructure.Entities;
+
+namespace Konnect.Infrastructure.Services.Companies.Commands;
+
+/// <summary>
+/// Write-side service for the <see cref="Company"/> aggregate. Phase 1
+/// exposes a single "edit your own company profile" command; later phases
+/// will add company verification, slug rename, archival, etc. Pairs with
+/// <see cref="Queries.ICompanyQueryService"/> for the read side.
+/// </summary>
+public interface ICompanyCommandService
+{
+    /// <summary>
+    /// Updates the company the recruiter (identified by their Auth0
+    /// <paramref name="recruiterExternalId"/>) belongs to. The recruiter
+    /// can only edit *their own* company — the service derives the target
+    /// company from the recruiter's <c>CompanyId</c> rather than trusting
+    /// any client-supplied identifier. Returns the updated <see cref="Company"/>.
+    /// </summary>
+    Task<Company> UpdateByRecruiterIdAsync(
+        Guid recruiterExternalId,
+        UpdateCompanyInput input,
+        CancellationToken cancellationToken);
+}

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Companies/Queries/ICompanyQueryService.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Companies/Queries/ICompanyQueryService.cs
@@ -1,0 +1,31 @@
+using Konnect.Infrastructure.Entities;
+
+namespace Konnect.Infrastructure.Services.Companies.Queries;
+
+/// <summary>
+/// Read-side service for the <see cref="Company"/> aggregate. Mirrors the
+/// GraphQL query surface: public slug-based lookup + recruiter-scoped
+/// "the company that this recruiter belongs to" lookup. Pairs with
+/// <see cref="Commands.ICompanyCommandService"/> for the write side.
+/// Lookup methods follow the repo-style <c>GetByXxxAsync</c> convention —
+/// the subject (<see cref="Company"/>) is implicit from the interface name.
+/// </summary>
+public interface ICompanyQueryService
+{
+    /// <summary>
+    /// Public lookup by URL-safe slug. Returns <c>null</c> if no company
+    /// matches — the GraphQL resolver bubbles that up as a nullable field.
+    /// </summary>
+    Task<Company?> GetBySlugAsync(string slug, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the company the recruiter (identified by their Auth0
+    /// <paramref name="recruiterExternalId"/>) belongs to. Throws
+    /// <see cref="InvalidOperationException"/> if the recruiter has no
+    /// domain row (the JWT was valid but #51 onboarding never ran for this
+    /// user — surface loudly rather than silently 404-ing).
+    /// </summary>
+    Task<Company> GetByRecruiterIdAsync(
+        Guid recruiterExternalId,
+        CancellationToken cancellationToken);
+}

--- a/Konnect.Platform/Konnect.Repositories/CompanyRepository.cs
+++ b/Konnect.Platform/Konnect.Repositories/CompanyRepository.cs
@@ -40,4 +40,15 @@ public sealed class CompanyRepository(KonnectDbContext dbContext) : ICompanyRepo
         await dbContext.SaveChangesAsync(cancellationToken);
         await transaction.CommitAsync(cancellationToken);
     }
+
+    public async Task UpdateAsync(Company company, CancellationToken cancellationToken)
+    {
+        var entry = dbContext.Entry(company);
+        if (entry.State == EntityState.Detached)
+        {
+            dbContext.Companies.Update(company);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/Konnect.Platform/Konnect.Repositories/Extensions/RepositoriesServiceCollectionExtensions.cs
+++ b/Konnect.Platform/Konnect.Repositories/Extensions/RepositoriesServiceCollectionExtensions.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
-namespace Konnect.Repositories;
+namespace Konnect.Repositories.Extensions;
 
 /// <summary>
 /// Single registration entry point for everything in <c>Konnect.Repositories</c> —

--- a/Konnect.Platform/Konnect.Services/Companies/Commands/CompanyCommandService.cs
+++ b/Konnect.Platform/Konnect.Services/Companies/Commands/CompanyCommandService.cs
@@ -1,0 +1,42 @@
+using Konnect.Infrastructure.Contracts.Companies;
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Repositories;
+using Konnect.Infrastructure.Services.Companies.Commands;
+
+namespace Konnect.Services.Companies.Commands;
+
+public sealed class CompanyCommandService(
+    IUserRepository userRepository,
+    ICompanyRepository companyRepository) : ICompanyCommandService
+{
+    public async Task<Company> UpdateByRecruiterIdAsync(
+        Guid recruiterExternalId,
+        UpdateCompanyInput input,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.Name);
+
+        // Belt-and-braces: the company being updated is derived from the
+        // recruiter's domain row, not from any client input. A recruiter
+        // simply has no path to update a different company's profile.
+        var recruiter = await userRepository.GetByIdAsync(recruiterExternalId, cancellationToken)
+            as RecruiterUser
+            ?? throw new InvalidOperationException(
+                $"No RecruiterUser exists for external_id {recruiterExternalId}. " +
+                "The SPA must call POST /api/recruiter/onboard before any recruiter-scoped mutation.");
+
+        var company = await companyRepository.GetByIdAsync(recruiter.CompanyId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Recruiter {recruiterExternalId} references missing company {recruiter.CompanyId}.");
+
+        company.Name = input.Name;
+        company.Description = input.Description;
+        company.WebsiteUrl = input.WebsiteUrl;
+
+        // updated_at is owned by the Postgres set_updated_at trigger.
+        await companyRepository.UpdateAsync(company, cancellationToken);
+
+        return company;
+    }
+}

--- a/Konnect.Platform/Konnect.Services/Companies/Queries/CompanyQueryService.cs
+++ b/Konnect.Platform/Konnect.Services/Companies/Queries/CompanyQueryService.cs
@@ -1,0 +1,31 @@
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Repositories;
+using Konnect.Infrastructure.Services.Companies.Queries;
+
+namespace Konnect.Services.Companies.Queries;
+
+public sealed class CompanyQueryService(
+    IUserRepository userRepository,
+    ICompanyRepository companyRepository) : ICompanyQueryService
+{
+    public Task<Company?> GetBySlugAsync(string slug, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slug);
+        return companyRepository.GetBySlugAsync(slug, cancellationToken);
+    }
+
+    public async Task<Company> GetByRecruiterIdAsync(
+        Guid recruiterExternalId,
+        CancellationToken cancellationToken)
+    {
+        var recruiter = await userRepository.GetByIdAsync(recruiterExternalId, cancellationToken)
+            as RecruiterUser
+            ?? throw new InvalidOperationException(
+                $"No RecruiterUser exists for external_id {recruiterExternalId}. " +
+                "The SPA must call POST /api/recruiter/onboard before any recruiter-scoped query.");
+
+        return await companyRepository.GetByIdAsync(recruiter.CompanyId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Recruiter {recruiterExternalId} references missing company {recruiter.CompanyId}.");
+    }
+}

--- a/Konnect.Platform/Konnect.Services/Extensions/ServicesServiceCollectionExtensions.cs
+++ b/Konnect.Platform/Konnect.Services/Extensions/ServicesServiceCollectionExtensions.cs
@@ -1,13 +1,19 @@
+using Konnect.Infrastructure.Services.Companies.Commands;
+using Konnect.Infrastructure.Services.Companies.Queries;
 using Konnect.Infrastructure.Services.Onboarding;
+using Konnect.Services.Companies.Commands;
+using Konnect.Services.Companies.Queries;
 using Konnect.Services.Onboarding;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Konnect.Services;
+namespace Konnect.Services.Extensions;
 
 /// <summary>
 /// Single registration entry point for everything in <c>Konnect.Services</c>.
 /// All Services are <c>Scoped</c> so they share the request-scoped DbContext
-/// transitively reached through their injected repositories.
+/// transitively reached through their injected repositories. Domain areas
+/// follow the CQRS-lite split — one Query service + one Command service per
+/// aggregate.
 /// </summary>
 public static class ServicesServiceCollectionExtensions
 {
@@ -15,6 +21,9 @@ public static class ServicesServiceCollectionExtensions
     {
         services.AddScoped<IRecruiterOnboardingService, RecruiterOnboardingService>();
         services.AddScoped<IJobSeekerOnboardingService, JobSeekerOnboardingService>();
+
+        services.AddScoped<ICompanyQueryService, CompanyQueryService>();
+        services.AddScoped<ICompanyCommandService, CompanyCommandService>();
 
         return services;
     }

--- a/Konnect.Platform/Konnect.Tests/GraphQL/Companies/CompanyGraphQLTests.cs
+++ b/Konnect.Platform/Konnect.Tests/GraphQL/Companies/CompanyGraphQLTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.Tests.Infrastructure;
+using Konnect.Tests.WebAPI.Authentication.Fixtures;
+
+namespace Konnect.Tests.GraphQL.Companies;
+
+/// <summary>
+/// End-to-end coverage for the Company GraphQL surface served from
+/// <c>/graphql</c>: the public <c>company(slug)</c> field, the recruiter-
+/// scoped <c>recruiter.company</c> field, and the auth gates on the
+/// recruiter wrapper. All requests go through the real ASP.NET pipeline
+/// against a Testcontainers Postgres so the HotChocolate authorization
+/// middleware + JwtBearer scheme are actually exercised.
+/// </summary>
+[Collection(DatabaseTestSuite.Name)]
+public sealed class CompanyGraphQLTests : IDisposable
+{
+    private readonly PostgresFixture _postgresFixture;
+    private readonly KonnectWebApplicationFactory _factory;
+
+    public CompanyGraphQLTests(PostgresFixture postgresFixture)
+    {
+        _postgresFixture = postgresFixture;
+        _factory = new KonnectWebApplicationFactory
+        {
+            PostgresConnectionString = postgresFixture.ConnectionString,
+        };
+    }
+
+    public void Dispose() => _factory.Dispose();
+
+    [Fact]
+    public async Task Should_ReturnCompany_When_PublicSlugQuery()
+    {
+        var (_, _, slug) = await SeedRecruiterWithCompany("Acme Public");
+        var client = _factory.CreateClient();
+
+        var json = await PostGraphQL(client, $"{{ company(slug: \"{slug}\") {{ slug name }} }}");
+
+        using var document = JsonDocument.Parse(json);
+        var company = document.RootElement.GetProperty("data").GetProperty("company");
+        Assert.Equal(slug, company.GetProperty("slug").GetString());
+        Assert.Equal("Acme Public", company.GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task Should_ReturnRecruitersOwnCompany_When_RecruiterScopedQuery()
+    {
+        var (recruiterId, _, slug) = await SeedRecruiterWithCompany("Acme Owned");
+        var client = CreateRecruiterClient(recruiterId);
+
+        var json = await PostGraphQL(client, "{ recruiter { company { slug name } } }");
+
+        using var document = JsonDocument.Parse(json);
+        Assert.False(document.RootElement.TryGetProperty("errors", out _));
+        var company = document.RootElement
+            .GetProperty("data")
+            .GetProperty("recruiter")
+            .GetProperty("company");
+        Assert.Equal(slug, company.GetProperty("slug").GetString());
+        Assert.Equal("Acme Owned", company.GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task Should_ReturnError_When_RecruiterScopedQueryHasNoToken()
+    {
+        var client = _factory.CreateClient();
+
+        var json = await PostGraphQL(client, "{ recruiter { company { slug } } }");
+
+        using var document = JsonDocument.Parse(json);
+        Assert.True(document.RootElement.TryGetProperty("errors", out _));
+    }
+
+    [Fact]
+    public async Task Should_ReturnError_When_SeekerTokenAccessesRecruiterScope()
+    {
+        var token = _factory.TokenFactory.CreateToken(
+            audience: KonnectWebApplicationFactory.SeekerAudience,
+            additionalClaims:
+            [
+                new(KonnectClaimTypes.ExternalId, Guid.NewGuid().ToString()),
+                new(KonnectClaimTypes.Role, JwtRoles.JobSeeker),
+                new("email", "seeker@example.test"),
+            ]);
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var json = await PostGraphQL(client, "{ recruiter { company { slug } } }");
+
+        using var document = JsonDocument.Parse(json);
+        Assert.True(document.RootElement.TryGetProperty("errors", out _));
+    }
+
+    private static async Task<string> PostGraphQL(HttpClient client, string query)
+    {
+        var response = await client.PostAsJsonAsync(
+            new Uri("/graphql", UriKind.Relative),
+            new { query });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    private async Task<(Guid RecruiterId, Guid CompanyId, string Slug)> SeedRecruiterWithCompany(string companyName)
+    {
+        var recruiterId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        var slug = $"acme-{Guid.NewGuid():N}";
+
+        await using var dbContext = _postgresFixture.CreateDbContext();
+        dbContext.Companies.Add(new Company
+        {
+            Id = companyId,
+            Name = companyName,
+            Slug = slug,
+        });
+        dbContext.Recruiters.Add(new RecruiterUser
+        {
+            Id = recruiterId,
+            Email = "alice@acme.test",
+            CompanyId = companyId,
+            FirstName = "Alice",
+            LastName = "Anderson",
+            JobTitle = "Recruiter",
+        });
+        await dbContext.SaveChangesAsync();
+
+        return (recruiterId, companyId, slug);
+    }
+
+    private HttpClient CreateRecruiterClient(Guid externalId)
+    {
+        var token = _factory.TokenFactory.CreateToken(
+            audience: KonnectWebApplicationFactory.EmployerAudience,
+            additionalClaims:
+            [
+                new(KonnectClaimTypes.ExternalId, externalId.ToString()),
+                new(KonnectClaimTypes.Role, JwtRoles.Recruiter),
+                new("email", "alice@acme.test"),
+            ]);
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+}

--- a/Konnect.Platform/Konnect.Tests/GraphQL/HealthcheckTests.cs
+++ b/Konnect.Platform/Konnect.Tests/GraphQL/HealthcheckTests.cs
@@ -1,6 +1,6 @@
 using HotChocolate;
 using HotChocolate.Execution;
-using Konnect.GraphQL;
+using Konnect.GraphQL.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Konnect.Tests.GraphQL;
@@ -11,6 +11,12 @@ public class HealthcheckTests
     public async Task GraphQL_HealthcheckQuery_Returns_Ok()
     {
         var services = new ServiceCollection();
+        // GraphQL's authorization middleware needs ASP.NET Core's
+        // IAuthorizationService (which itself needs logging) at execution
+        // time, even for fields that aren't gated. Production gets these via
+        // Program.cs; this standalone harness wires the bare minimum.
+        services.AddLogging();
+        services.AddAuthorization();
         services.AddKonnectGraphQL();
         await using var serviceProvider = services.BuildServiceProvider();
 

--- a/Konnect.Platform/Konnect.Tests/Services/Companies/Commands/CompanyCommandServiceTests.cs
+++ b/Konnect.Platform/Konnect.Tests/Services/Companies/Commands/CompanyCommandServiceTests.cs
@@ -1,0 +1,122 @@
+using Konnect.Infrastructure.Contracts.Companies;
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Repositories;
+using Konnect.Services.Companies.Commands;
+using NSubstitute;
+
+namespace Konnect.Tests.Services.Companies.Commands;
+
+/// <summary>
+/// Pins the write-side orchestration of <see cref="CompanyCommandService"/>:
+/// the recruiter can only edit their own company (target derived from their
+/// domain row, never from input), the editable fields are exactly Name /
+/// Description / WebsiteUrl, and every error path short-circuits before the
+/// repository is asked to UPDATE.
+/// </summary>
+public class CompanyCommandServiceTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ICompanyRepository _companyRepository = Substitute.For<ICompanyRepository>();
+    private readonly CompanyCommandService _service;
+
+    public CompanyCommandServiceTests()
+    {
+        _service = new CompanyCommandService(_userRepository, _companyRepository);
+    }
+
+    [Fact]
+    public async Task Should_UpdateNameDescriptionAndWebsite_When_Happy()
+    {
+        var recruiterId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(recruiterId, Arg.Any<CancellationToken>())
+            .Returns(new RecruiterUser { Id = recruiterId, CompanyId = companyId });
+        var company = new Company
+        {
+            Id = companyId,
+            Slug = "acme",
+            Name = "Old Name",
+            Description = "Old description",
+            WebsiteUrl = "https://old.test",
+        };
+        _companyRepository.GetByIdAsync(companyId, Arg.Any<CancellationToken>())
+            .Returns(company);
+
+        var input = new UpdateCompanyInput("New Name", "New description", "https://new.test");
+
+        var result = await _service.UpdateByRecruiterIdAsync(recruiterId, input, CancellationToken.None);
+
+        Assert.Same(company, result);
+        Assert.Equal("New Name", company.Name);
+        Assert.Equal("New description", company.Description);
+        Assert.Equal("https://new.test", company.WebsiteUrl);
+        Assert.Equal("acme", company.Slug); // slug is not editable here
+        await _companyRepository.Received(1).UpdateAsync(company, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_ThrowArgumentNullException_When_InputIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => _service.UpdateByRecruiterIdAsync(Guid.NewGuid(), null!, CancellationToken.None));
+
+        await _companyRepository.DidNotReceive().UpdateAsync(
+            Arg.Any<Company>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_ThrowArgumentException_When_InputNameIsBlank()
+    {
+        var input = new UpdateCompanyInput("   ", null, null);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.UpdateByRecruiterIdAsync(Guid.NewGuid(), input, CancellationToken.None));
+
+        await _companyRepository.DidNotReceive().UpdateAsync(
+            Arg.Any<Company>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_ThrowInvalidOperation_When_RecruiterMissing()
+    {
+        _userRepository.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+
+        var input = new UpdateCompanyInput("New", null, null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.UpdateByRecruiterIdAsync(Guid.NewGuid(), input, CancellationToken.None));
+
+        await _companyRepository.DidNotReceive().UpdateAsync(
+            Arg.Any<Company>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_ThrowInvalidOperation_When_UserIsSeeker()
+    {
+        var id = Guid.NewGuid();
+        _userRepository.GetByIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns(new JobSeekerUser { Id = id, Email = "seeker@example.test" });
+
+        var input = new UpdateCompanyInput("New", null, null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.UpdateByRecruiterIdAsync(id, input, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Should_ThrowInvalidOperation_When_RecruiterReferencesMissingCompany()
+    {
+        var recruiterId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(recruiterId, Arg.Any<CancellationToken>())
+            .Returns(new RecruiterUser { Id = recruiterId, CompanyId = companyId });
+        _companyRepository.GetByIdAsync(companyId, Arg.Any<CancellationToken>())
+            .Returns((Company?)null);
+
+        var input = new UpdateCompanyInput("New", null, null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.UpdateByRecruiterIdAsync(recruiterId, input, CancellationToken.None));
+    }
+}

--- a/Konnect.Platform/Konnect.Tests/Services/Companies/Queries/CompanyQueryServiceTests.cs
+++ b/Konnect.Platform/Konnect.Tests/Services/Companies/Queries/CompanyQueryServiceTests.cs
@@ -1,0 +1,107 @@
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Repositories;
+using Konnect.Services.Companies.Queries;
+using NSubstitute;
+
+namespace Konnect.Tests.Services.Companies.Queries;
+
+/// <summary>
+/// Pins the read-side orchestration of <see cref="CompanyQueryService"/>:
+/// public slug lookup is a thin pass-through to the repo (with input
+/// validation), and the recruiter-scoped lookup must derive the company id
+/// from the recruiter's domain row, never from the caller. Each error path
+/// is exercised so a refactor cannot silently downgrade the recruiter-scope
+/// guarantees.
+/// </summary>
+public class CompanyQueryServiceTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ICompanyRepository _companyRepository = Substitute.For<ICompanyRepository>();
+    private readonly CompanyQueryService _service;
+
+    public CompanyQueryServiceTests()
+    {
+        _service = new CompanyQueryService(_userRepository, _companyRepository);
+    }
+
+    [Fact]
+    public async Task Should_DelegateToRepository_When_GetBySlug()
+    {
+        var company = new Company { Id = Guid.NewGuid(), Slug = "acme", Name = "Acme" };
+        _companyRepository.GetBySlugAsync("acme", Arg.Any<CancellationToken>())
+            .Returns(company);
+
+        var result = await _service.GetBySlugAsync("acme", CancellationToken.None);
+
+        Assert.Same(company, result);
+    }
+
+    [Fact]
+    public async Task Should_ReturnNull_When_GetBySlugMissing()
+    {
+        _companyRepository.GetBySlugAsync("ghost", Arg.Any<CancellationToken>())
+            .Returns((Company?)null);
+
+        var result = await _service.GetBySlugAsync("ghost", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Should_ThrowArgumentException_When_GetBySlugIsBlank()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.GetBySlugAsync("   ", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Should_ReturnRecruitersCompany_When_GetByRecruiterIdHappy()
+    {
+        var recruiterId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(recruiterId, Arg.Any<CancellationToken>())
+            .Returns(new RecruiterUser { Id = recruiterId, CompanyId = companyId });
+        var company = new Company { Id = companyId, Slug = "acme" };
+        _companyRepository.GetByIdAsync(companyId, Arg.Any<CancellationToken>())
+            .Returns(company);
+
+        var result = await _service.GetByRecruiterIdAsync(recruiterId, CancellationToken.None);
+
+        Assert.Same(company, result);
+    }
+
+    [Fact]
+    public async Task Should_ThrowInvalidOperation_When_GetByRecruiterIdMissingUser()
+    {
+        _userRepository.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.GetByRecruiterIdAsync(Guid.NewGuid(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Should_ThrowInvalidOperation_When_GetByRecruiterIdAndUserIsSeeker()
+    {
+        var id = Guid.NewGuid();
+        _userRepository.GetByIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns(new JobSeekerUser { Id = id, Email = "seeker@example.test" });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.GetByRecruiterIdAsync(id, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Should_ThrowInvalidOperation_When_GetByRecruiterIdReferencesMissingCompany()
+    {
+        var recruiterId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(recruiterId, Arg.Any<CancellationToken>())
+            .Returns(new RecruiterUser { Id = recruiterId, CompanyId = companyId });
+        _companyRepository.GetByIdAsync(companyId, Arg.Any<CancellationToken>())
+            .Returns((Company?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.GetByRecruiterIdAsync(recruiterId, CancellationToken.None));
+    }
+}

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Companies/RecruiterCompanyTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Companies/RecruiterCompanyTests.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Konnect.Infrastructure.Contracts.Companies;
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.Tests.Infrastructure;
+using Konnect.Tests.WebAPI.Authentication.Fixtures;
+using Microsoft.EntityFrameworkCore;
+
+namespace Konnect.Tests.WebAPI.Companies;
+
+/// <summary>
+/// End-to-end coverage for <c>PUT /api/recruiter/company</c>: controller +
+/// service + repository chain against a real Testcontainers Postgres.
+/// Confirms a recruiter updates their own company in place, the slug stays
+/// untouched (only Name / Description / WebsiteUrl are editable), and the
+/// auth gates reject anonymous + cross-role tokens.
+/// </summary>
+[Collection(DatabaseTestSuite.Name)]
+public sealed class RecruiterCompanyTests : IDisposable
+{
+    private readonly PostgresFixture _postgresFixture;
+    private readonly KonnectWebApplicationFactory _factory;
+
+    public RecruiterCompanyTests(PostgresFixture postgresFixture)
+    {
+        _postgresFixture = postgresFixture;
+        _factory = new KonnectWebApplicationFactory
+        {
+            PostgresConnectionString = postgresFixture.ConnectionString,
+        };
+    }
+
+    public void Dispose() => _factory.Dispose();
+
+    [Fact]
+    public async Task Should_Return200_AndPersistChanges_When_RecruiterUpdatesOwnCompany()
+    {
+        var (recruiterId, companyId, originalSlug) = await SeedRecruiterWithCompany();
+        var client = CreateRecruiterClient(recruiterId);
+
+        var response = await client.PutAsJsonAsync(
+            new Uri("/api/recruiter/company", UriKind.Relative),
+            new UpdateCompanyInput(
+                Name: "Acme Renamed",
+                Description: "Renamed description",
+                WebsiteUrl: "https://renamed.test"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await using var dbContext = _postgresFixture.CreateDbContext();
+        var refreshed = await dbContext.Companies
+            .AsNoTracking()
+            .FirstAsync(record => record.Id == companyId);
+
+        Assert.Equal("Acme Renamed", refreshed.Name);
+        Assert.Equal("Renamed description", refreshed.Description);
+        Assert.Equal("https://renamed.test", refreshed.WebsiteUrl);
+        Assert.Equal(originalSlug, refreshed.Slug);
+    }
+
+    [Fact]
+    public async Task Should_Return403_When_SeekerTokenSentToRecruiterEndpoint()
+    {
+        var token = _factory.TokenFactory.CreateToken(
+            audience: KonnectWebApplicationFactory.SeekerAudience,
+            additionalClaims:
+            [
+                new(KonnectClaimTypes.ExternalId, Guid.NewGuid().ToString()),
+                new(KonnectClaimTypes.Role, JwtRoles.JobSeeker),
+                new("email", "seeker@example.test"),
+            ]);
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.PutAsJsonAsync(
+            new Uri("/api/recruiter/company", UriKind.Relative),
+            new UpdateCompanyInput("Whatever", null, null));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Should_Return401_When_NoBearerToken()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PutAsJsonAsync(
+            new Uri("/api/recruiter/company", UriKind.Relative),
+            new UpdateCompanyInput("Whatever", null, null));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private async Task<(Guid RecruiterId, Guid CompanyId, string Slug)> SeedRecruiterWithCompany()
+    {
+        var recruiterId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        var slug = $"acme-{Guid.NewGuid():N}";
+
+        await using var dbContext = _postgresFixture.CreateDbContext();
+        dbContext.Companies.Add(new Company
+        {
+            Id = companyId,
+            Name = "Acme Original",
+            Slug = slug,
+            Description = "Original description",
+            WebsiteUrl = "https://original.test",
+            Verified = false,
+        });
+        dbContext.Recruiters.Add(new RecruiterUser
+        {
+            Id = recruiterId,
+            Email = "alice@acme.test",
+            CompanyId = companyId,
+            FirstName = "Alice",
+            LastName = "Anderson",
+            JobTitle = "Recruiter",
+        });
+        await dbContext.SaveChangesAsync();
+
+        return (recruiterId, companyId, slug);
+    }
+
+    private HttpClient CreateRecruiterClient(Guid externalId)
+    {
+        var token = _factory.TokenFactory.CreateToken(
+            audience: KonnectWebApplicationFactory.EmployerAudience,
+            additionalClaims:
+            [
+                new(KonnectClaimTypes.ExternalId, externalId.ToString()),
+                new(KonnectClaimTypes.Role, JwtRoles.Recruiter),
+                new("email", "alice@acme.test"),
+            ]);
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+}

--- a/Konnect.Platform/Konnect.WebAPI/Controllers/Recruiter/RecruiterCompanyController.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Controllers/Recruiter/RecruiterCompanyController.cs
@@ -1,0 +1,52 @@
+using Konnect.Infrastructure.Contracts.Companies;
+using Konnect.Infrastructure.Entities;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.Infrastructure.Services.Companies.Commands;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Konnect.WebAPI.Controllers.Recruiter;
+
+/// <summary>
+/// Recruiter-scoped Company commands. Identity always comes from the JWT —
+/// never from the route or body — so a recruiter can only ever modify their
+/// own company. Reads live on the GraphQL surface
+/// (<c>Query.recruiter.company</c>); this controller is the write side.
+/// </summary>
+[ApiController]
+[Route("api/recruiter/company")]
+[Authorize(Roles = JwtRoles.Recruiter)]
+public sealed class RecruiterCompanyController(ICompanyCommandService companyCommandService) : ControllerBase
+{
+    [HttpPut]
+    public async Task<IActionResult> Update(
+        [FromBody] UpdateCompanyInput input,
+        CancellationToken cancellationToken)
+    {
+        var company = await companyCommandService.UpdateByRecruiterIdAsync(
+            User.GetExternalId(),
+            input,
+            cancellationToken);
+
+        return Ok(ToResponse(company));
+    }
+
+    private static UpdateCompanyResponse ToResponse(Company company)
+        => new(
+            company.Id,
+            company.Name,
+            company.Slug,
+            company.Description,
+            company.WebsiteUrl,
+            company.Verified,
+            company.UpdatedAt);
+}
+
+public sealed record UpdateCompanyResponse(
+    Guid Id,
+    string Name,
+    string Slug,
+    string? Description,
+    string? WebsiteUrl,
+    bool Verified,
+    DateTimeOffset UpdatedAt);

--- a/Konnect.Platform/Konnect.WebAPI/Middleware/KonnectAuthenticationMiddleware.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Middleware/KonnectAuthenticationMiddleware.cs
@@ -19,14 +19,9 @@ namespace Konnect.WebAPI.Middleware;
 /// a real Auth0-signed token, but we still treat the rejection as
 /// operational noise rather than a system error.
 /// </summary>
-public sealed class KonnectAuthenticationMiddleware
+public sealed class KonnectAuthenticationMiddleware(RequestDelegate next)
 {
-    private readonly RequestDelegate next;
-
-    public KonnectAuthenticationMiddleware(RequestDelegate next)
-    {
-        this.next = next;
-    }
+    private readonly RequestDelegate next = next;
 
     public async Task InvokeAsync(HttpContext context, ILogger<KonnectAuthenticationMiddleware> logger)
     {

--- a/Konnect.Platform/Konnect.WebAPI/Program.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Program.cs
@@ -1,8 +1,8 @@
-using Konnect.GraphQL;
+using Konnect.GraphQL.Extensions;
 using Konnect.Infrastructure.Repositories;
 using Konnect.Infrastructure.Services.Authentication;
-using Konnect.Repositories;
-using Konnect.Services;
+using Konnect.Repositories.Extensions;
+using Konnect.Services.Extensions;
 using Konnect.WebAPI.Middleware;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Options;

--- a/wikis/Architecture.md
+++ b/wikis/Architecture.md
@@ -115,15 +115,20 @@ Today, the routes that respond are:
 | `GET /api/me` | The authenticated caller's `external_id`, `role`, and `email`, distilled from JWT claims. Useful as an auth smoke test from the SPAs. | `[Authorize]` |
 | `POST /api/recruiter/onboard` | Provisions the `Company` + first `RecruiterUser` row after the SPA's first Auth0 sign-in. Idempotent on the JWT `external_id` claim. See [Onboarding](api/Onboarding). | `[Authorize(Roles = "Recruiter")]` |
 | `POST /api/seeker/onboard` | Provisions the `JobSeekerUser` row after the SPA's first Auth0 sign-in. Idempotent. | `[Authorize(Roles = "JobSeeker")]` |
-| `POST /graphql` | The single query `{ healthcheck }` — see [`Konnect.GraphQL/Schema/Query.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.GraphQL/Schema/Query.cs) | anonymous |
+| `PUT /api/recruiter/company` | Updates the recruiter's own company (name / description / website). Slug is not editable here. See [GraphQL — Companies](api/GraphQL-Companies). | `[Authorize(Roles = "Recruiter")]` |
+| `POST /graphql` — `Query.healthcheck` | Schema smoke test — see [`Konnect.GraphQL/Schema/Query.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.GraphQL/Schema/Query.cs) | anonymous |
+| `POST /graphql` — `Query.company(slug)` | Public lookup of a company by URL slug. Powers the public profile page. | anonymous |
+| `POST /graphql` — `Query.recruiter.company` | The recruiter's own company. Target derived from the JWT `external_id`, never from arguments. See [GraphQL — Companies](api/GraphQL-Companies). | `@authorize(roles: ["Recruiter"])` on the `recruiter` wrapper |
 | `GET /graphql` *(dev only)* | Banana Cake Pop / Nitro UI | anonymous |
 | `GET /openapi/v1.json` *(dev only)* | OpenAPI document | anonymous |
+
+The split between transports is deliberate: **GraphQL serves queries, REST serves commands.** The schema therefore has a `Query` root but no `Mutation` root — every state-changing operation lives on a REST controller. This maps cleanly onto the CQRS-lite split in `Konnect.Services/<DomainArea>/{Queries,Commands}/` (query services back resolvers, command services back controllers), so changing transport or scaling the read side independently is a one-layer change.
 
 Authentication is delegated to **Auth0** — Konnect never stores passwords, never issues JWTs, and holds no refresh-token state. The full picture (tenant setup, the two Auth0 Actions, the audience-split, the operational note about the Pre-User-Registration Action) lives on the [Authentication — Auth0](api/Authentication-Auth0) page. Identity-to-domain handshake (the post-Auth0 onboarding step that creates the `JobSeekerUser` / `RecruiterUser` + `Company` rows) is documented on the [Onboarding](api/Onboarding) page.
 
 Audit timestamps (`created_at`, `updated_at`) are owned by Postgres: a column default plus a `BEFORE UPDATE` trigger calling a shared `set_updated_at()` function. Application services never assign these — keeps the application clock and DB clock from skewing, and the schema stays correct even if a non-EF caller (psql, ETL) writes rows. See [`Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.cs).
 
-The convention: each cross-cutting concern is registered through a single extension method that lives in the project that owns it. `AddKonnectGraphQL()` lives in [`Konnect.GraphQL/GraphQLServiceCollectionExtensions.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.GraphQL/GraphQLServiceCollectionExtensions.cs). Future concerns follow the same shape — `Program.cs` stays a short list of capabilities, not a wiring tangle.
+The convention: each cross-cutting concern is registered through a single extension method that lives in an `Extensions/` folder of the project that owns it. `AddKonnectGraphQL()` lives in [`Konnect.GraphQL/Extensions/GraphQLServiceCollectionExtensions.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.GraphQL/Extensions/GraphQLServiceCollectionExtensions.cs); the same pattern is used by `Konnect.Repositories/Extensions/` and `Konnect.Services/Extensions/`. One well-known folder per project means there's exactly one place to look when wiring or troubleshooting registrations, and `Program.cs` stays a short list of capabilities rather than a wiring tangle.
 
 ## Local infrastructure
 

--- a/wikis/Features.md
+++ b/wikis/Features.md
@@ -50,7 +50,7 @@ Out-of-date rows are bugs.
 | Feature | Status | Issue / Story | Wiki |
 |---|---|---|---|
 | Multi-recruiter Company model (Company has many Recruiter; recruiter role from Auth0 JWT claim, no Identity role table) | In Progress | [#46](https://github.com/win-son-dev/konnect-server/issues/46) | [Database Schema](infrastructure/Database-Schema) |
-| Company GraphQL — public `Query.company(slug)` + recruiter-scoped queries / `updateCompany` mutation | Planned | [#24](https://github.com/win-son-dev/konnect-server/issues/24) | — |
+| Company GraphQL — public `Query.company(slug)` + recruiter-scoped `Query.recruiter.company` + `PUT /api/recruiter/company` write endpoint | Shipped | [#24](https://github.com/win-son-dev/konnect-server/issues/24) | [GraphQL — Companies](api/GraphQL-Companies) |
 | Recruiter invitation flow (existing CompanyAdmin invites another recruiter) | Planned | _(deferred to Phase 1.5 — needs email infrastructure)_ | — |
 
 ## Job postings

--- a/wikis/Home.md
+++ b/wikis/Home.md
@@ -18,6 +18,9 @@ This wiki is the deep-dive layer for collaborators. The repo `README.md` is the 
   - [CI Pipeline](infrastructure/CI-Pipeline)
 - **[Features](Features)** — index of every feature Konnect ships or plans to ship, with status (Planned / In Progress / Shipped) and links to the GitHub Story that holds the spec. Per-feature deep-dive pages get added under `wikis/features/` when each feature ships.
 - **API** — endpoint pages get added when each endpoint is implemented.
+  - [Authentication — Auth0](api/Authentication-Auth0)
+  - [Onboarding](api/Onboarding)
+  - [GraphQL — Companies](api/GraphQL-Companies)
 
 ## Documentation principle
 

--- a/wikis/api/GraphQL-Companies.md
+++ b/wikis/api/GraphQL-Companies.md
@@ -1,0 +1,168 @@
+# GraphQL — Companies
+
+The first GraphQL type backed by real data. Public visitors can look up any company by slug; the company's own recruiter can view their company through a recruiter-scoped subtree. Updates go through the REST surface (see [Update endpoint](#update-endpoint)) — Konnect's transport split is **GraphQL = queries (reads), REST = commands (writes)**, so the GraphQL schema has no `Mutation` root.
+
+## Schema
+
+```graphql
+type Query {
+  healthcheck: String!
+  company(slug: String!): Company
+  recruiter: RecruiterQueries! @authorize(roles: ["Recruiter"])
+}
+
+type RecruiterQueries {
+  company: Company!
+}
+
+type Company {
+  id: UUID!
+  name: String!
+  slug: String!
+  description: String
+  websiteUrl: String
+  verified: Boolean!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+```
+
+`Company` deliberately does **not** expose `Recruiters` or `JobPostings` — the public schema is for browse/profile, recruiter rosters are never world-readable, and job postings will land on a separate top-level field once issue #25 ships rather than as a nested projection.
+
+## Public — `Query.company(slug)`
+
+Anonymous lookup. Powers the public company profile page.
+
+### Request
+
+```http
+POST /graphql
+Content-Type: application/json
+
+{
+  "query": "{ company(slug: \"acme\") { id name slug description websiteUrl verified } }"
+}
+```
+
+### Response
+
+```json
+{
+  "data": {
+    "company": {
+      "id": "8f9a4d2b-9d3a-4f1c-9c1e-2a8e1f7b1c2d",
+      "name": "Acme Corp",
+      "slug": "acme",
+      "description": "We make anvils.",
+      "websiteUrl": "https://acme.test",
+      "verified": false
+    }
+  }
+}
+```
+
+Returns `null` inside `data.company` if no company has the slug.
+
+## Recruiter-scoped — `Query.recruiter.company`
+
+Requires a recruiter access token. The target company is derived from the recruiter's JWT `external_id` claim — there is no `slug` or `id` argument, so a recruiter cannot read another recruiter's company through this field.
+
+The wrapper field `Query.recruiter` carries `[Authorize(Roles = "Recruiter")]`; every nested field (today only `company`, more once #25 lands) is gated by virtue of being reachable through it.
+
+### Request
+
+```http
+POST /graphql
+Authorization: Bearer <recruiter access_token>
+Content-Type: application/json
+
+{
+  "query": "{ recruiter { company { id name slug description websiteUrl } } }"
+}
+```
+
+### Response
+
+```json
+{
+  "data": {
+    "recruiter": {
+      "company": {
+        "id": "8f9a4d2b-9d3a-4f1c-9c1e-2a8e1f7b1c2d",
+        "name": "Acme Corp",
+        "slug": "acme",
+        "description": "We make anvils.",
+        "websiteUrl": "https://acme.test"
+      }
+    }
+  }
+}
+```
+
+| Token | Result |
+|---|---|
+| No token | GraphQL response with `errors[].extensions.code = "AUTH_NOT_AUTHENTICATED"` |
+| Seeker token | GraphQL response with `errors[].extensions.code = "AUTH_NOT_AUTHORIZED"` |
+| Recruiter token | `data.recruiter.company` populated |
+
+The wrapper subtree returns whatever the recruiter is authorised to see; querying `recruiter` itself does not 401 the HTTP response (HotChocolate keeps GraphQL authorisation failures inside the JSON envelope), it surfaces them as `errors`.
+
+## Update endpoint
+
+Writes are REST. The endpoint pairs with the recruiter-scoped read field above; identity always comes from the JWT, so a recruiter can only ever update their own company.
+
+### `PUT /api/recruiter/company`
+
+```http
+PUT /api/recruiter/company
+Authorization: Bearer <recruiter access_token>
+Content-Type: application/json
+
+{
+  "name": "Acme Renamed",
+  "description": "We now make jet engines.",
+  "websiteUrl": "https://acme-renamed.test"
+}
+```
+
+| Token | Status |
+|---|---|
+| No token | `401 Unauthorized` |
+| Seeker token | `403 Forbidden` |
+| Recruiter token | `200 OK` with the updated company body |
+
+`slug` is intentionally not editable here — slug renames touch caches and inbound links and will land as a separate operation if/when product asks for it. `verified` is set by Konnect, not by recruiters. `created_at` / `updated_at` are owned by Postgres (column default + `set_updated_at()` trigger) and never assigned by the application.
+
+### Response
+
+```json
+{
+  "id": "8f9a4d2b-9d3a-4f1c-9c1e-2a8e1f7b1c2d",
+  "name": "Acme Renamed",
+  "slug": "acme",
+  "description": "We now make jet engines.",
+  "websiteUrl": "https://acme-renamed.test",
+  "verified": false,
+  "updatedAt": "2026-05-11T08:14:22.391+00:00"
+}
+```
+
+## How the layers fit
+
+```
+GraphQL resolver (CompanyQueries / RecruiterCompanyQueries)
+        │
+        ▼
+ICompanyQueryService     ──── reads
+                              ┌─ ICompanyRepository.GetBySlugAsync
+                              └─ IUserRepository + ICompanyRepository.GetByIdAsync
+
+REST controller (RecruiterCompanyController)
+        │
+        ▼
+ICompanyCommandService   ──── writes
+                              └─ ICompanyRepository.UpdateAsync
+                                  (UPDATE; updated_at refreshed by Postgres trigger)
+```
+
+The CQRS-lite split (`Konnect.Services/Companies/{Queries,Commands}/`) maps directly onto the transport split: query services back GraphQL resolvers, command services back REST controllers. Repositories stay unified — the data shape is identical on both sides.


### PR DESCRIPTION
Closes #24.

First GraphQL type backed by real data. Public visitors look up any company by slug; a recruiter views their own company through a nested recruiter scope; updates go through a REST endpoint.

## Summary

- **GraphQL (reads)** — `Query.company(slug)` public, `Query.recruiter.company` recruiter-gated. `CompanyType` hides nav collections; the recruiter wrapper carries `[Authorize(Roles = JwtRoles.Recruiter)]` once so every nested field is gated.
- **REST (writes)** — `PUT /api/recruiter/company` updates the recruiter's own company. Target is derived from the JWT `external_id`, not from input.
- **Service layer** — CQRS-lite split: `ICompanyQueryService` backs the GraphQL resolvers, `ICompanyCommandService` backs the REST controller. Repository stays unified (`CompanyRepository.UpdateAsync` added).
- **Transport convention** — GraphQL = queries, REST = commands. The schema has no `Mutation` root, by design.

## Notable divergences from the original #24 spec

The issue spec predates several recent architectural decisions. Each divergence is intentional and tracked in project memory:

- **"Recruiter" instead of "Employer"** — domain term in code/API/Auth0 audience.
- **No "my" in code or API names** — `Query.recruiter.company` (not `myCompany`); service `GetByRecruiterIdAsync` (not `GetMyCompanyAsync`).
- **CQRS-lite service split** — two services per domain instead of one `ICompanyService`.
- **GraphQL queries / REST commands** — no `Mutation.recruiter.updateCompany`; the write is a REST endpoint.
- **`CompanyAdmin` distinction deferred** — Phase 1 is one recruiter per company, so admin-vs-member gates nothing. Belt-and-braces cross-company check still in place (service derives target from the recruiter's row, never trusts input).

## Other changes in this PR

- DI extension classes consolidated under each project's `Extensions/` folder (`Konnect.<Project>.Extensions` namespace). Three existing files moved; `Program.cs` updated.
- `ClaimsPrincipal.GetExternalId()` extension method as the single accessor for the Konnect external_id JWT claim. Returns `Guid.Empty` on missing rather than throwing — no DoS surface if an attacker ever reached the helper with malformed input.
- HotChocolate v16 wiring uses `[ExtendObjectType(typeof(Query))]` / `[ExtendObjectType(typeof(RecruiterQueries))]` so resolver classes get primary-constructor DI for services rather than `[Service]`-attribute method parameters.
- Wiki: new `wikis/api/GraphQL-Companies.md`; `Architecture.md` route table + extension-folder note; `Features.md` row flipped to Shipped; `Home.md` API index gains the new page.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test` — **69/69 passing** including:
  - `CompanyQueryServiceTests` (7) — happy + recruiter-not-found + seeker-as-recruiter + company-not-found
  - `CompanyCommandServiceTests` (6) — happy update + null/blank input + recruiter / company guards
  - `RecruiterCompanyTests` (3) — PUT happy path against real Postgres, seeker → 403, anon → 401
  - `CompanyGraphQLTests` (4) — public `company(slug)`, recruiter `recruiter.company`, anon error, seeker error
- [x] Manual smoke: `dotnet run` + hit `{ company(slug: "...") }` from Banana Cake Pop
- [x] Manual smoke: `PUT /api/recruiter/company` with a recruiter token; confirm row updates and `updated_at` advances