### PR TITLE
feature(auth): named authorization policies + audience-boundary test sweep

### DIFF
--- a/Konnect.Platform/Konnect.GraphQL/Schema/Query.cs
+++ b/Konnect.Platform/Konnect.GraphQL/Schema/Query.cs
@@ -16,6 +16,6 @@ public class Query
 {
     public string Healthcheck() => "ok";
 
-    [Authorize(Roles = [JwtRoles.Recruiter])]
+    [Authorize(Policy = AuthorizationPolicyNames.RecruiterAudience)]
     public RecruiterQueries Recruiter() => new();
 }

--- a/Konnect.Platform/Konnect.GraphQL/Schema/RecruiterQueries.cs
+++ b/Konnect.Platform/Konnect.GraphQL/Schema/RecruiterQueries.cs
@@ -2,9 +2,9 @@ namespace Konnect.GraphQL.Schema;
 
 /// <summary>
 /// Wrapper type for recruiter-scoped GraphQL query fields. Mounted under
-/// <c>Query.recruiter</c>; the parent field carries
-/// <c>[Authorize(Roles = JwtRoles.Recruiter)]</c>, so every nested field is
-/// gated by virtue of being reachable. Concrete fields live on per-feature
+/// <c>Query.recruiter</c>; the parent field carries the
+/// <c>RecruiterAudience</c> policy so every nested field is gated by virtue
+/// of being reachable. Concrete fields live on per-feature
 /// <c>[ExtendObjectType(typeof(RecruiterQueries))]</c> classes (see e.g.
 /// <c>RecruiterCompanyQueries</c>) — each owns its own constructor-injected
 /// services.

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Authentication/Auth0Settings.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Authentication/Auth0Settings.cs
@@ -25,8 +25,8 @@ public sealed record Auth0Settings
     public string SeekerAudience { get; set; } = string.Empty;
 
     /// <summary>
-    /// The audience identifier of the employer-side Auth0 API resource.
-    /// Example: <c>https://api.konnect.dev/employer</c>.
+    /// The audience identifier of the recruiter-side Auth0 API resource.
+    /// Example: <c>https://api.konnect.dev/recruiter</c>.
     /// </summary>
-    public string EmployerAudience { get; set; } = string.Empty;
+    public string RecruiterAudience { get; set; } = string.Empty;
 }

--- a/Konnect.Platform/Konnect.Infrastructure/Services/Authentication/AuthorizationPolicyNames.cs
+++ b/Konnect.Platform/Konnect.Infrastructure/Services/Authentication/AuthorizationPolicyNames.cs
@@ -1,0 +1,26 @@
+namespace Konnect.Infrastructure.Services.Authentication;
+
+/// <summary>
+/// Named ASP.NET Core authorization policies. Referenced from
+/// <c>[Authorize(Policy = ...)]</c> attributes on REST controllers and from
+/// HotChocolate <c>[Authorize(Policy = ...)]</c> attributes on GraphQL
+/// resolvers. The constants live in <c>Konnect.Infrastructure</c> so both
+/// <c>Konnect.WebAPI</c> and <c>Konnect.GraphQL</c> can reference the same
+/// names without circular project references. Concrete policy registration
+/// (requirements + handlers) lives in <c>Konnect.WebAPI/Authorization</c>.
+/// </summary>
+public static class AuthorizationPolicyNames
+{
+    /// <summary>
+    /// JWT must carry the seeker-side <c>aud</c> claim AND the
+    /// <c>JobSeeker</c> role. Both checks are independent — a recruiter token
+    /// re-issued with the seeker audience (or vice versa) is still rejected.
+    /// </summary>
+    public const string SeekerAudience = "SeekerAudience";
+
+    /// <summary>
+    /// JWT must carry the recruiter-side <c>aud</c> claim AND the
+    /// <c>Recruiter</c> role.
+    /// </summary>
+    public const string RecruiterAudience = "RecruiterAudience";
+}

--- a/Konnect.Platform/Konnect.Tests/GraphQL/Companies/CompanyGraphQLTests.cs
+++ b/Konnect.Platform/Konnect.Tests/GraphQL/Companies/CompanyGraphQLTests.cs
@@ -137,7 +137,7 @@ public sealed class CompanyGraphQLTests : IDisposable
     private HttpClient CreateRecruiterClient(Guid externalId)
     {
         var token = _factory.TokenFactory.CreateToken(
-            audience: KonnectWebApplicationFactory.EmployerAudience,
+            audience: KonnectWebApplicationFactory.RecruiterAudience,
             additionalClaims:
             [
                 new(KonnectClaimTypes.ExternalId, externalId.ToString()),

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/AuthenticationPipelineTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/AuthenticationPipelineTests.cs
@@ -50,10 +50,10 @@ public class AuthenticationPipelineTests(KonnectWebApplicationFactory factory)
     }
 
     [Fact]
-    public async Task Should_Return200_When_TokenAudienceIsEmployerSide()
+    public async Task Should_Return200_When_TokenAudienceIsRecruiterSide()
     {
         var token = factory.TokenFactory.CreateToken(
-            audience: KonnectWebApplicationFactory.EmployerAudience,
+            audience: KonnectWebApplicationFactory.RecruiterAudience,
             additionalClaims:
             [
                 new(KonnectClaimTypes.ExternalId, Guid.NewGuid().ToString()),

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/Fixtures/KonnectWebApplicationFactory.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Authentication/Fixtures/KonnectWebApplicationFactory.cs
@@ -25,7 +25,7 @@ public class KonnectWebApplicationFactory : WebApplicationFactory<WebApiEntryPoi
 
     public const string SeekerAudience = "https://api.konnect.test/seeker";
 
-    public const string EmployerAudience = "https://api.konnect.test/employer";
+    public const string RecruiterAudience = "https://api.konnect.test/recruiter";
 
     /// <summary>
     /// Postgres connection string the test host should bind to. Defaults to a
@@ -61,7 +61,7 @@ public class KonnectWebApplicationFactory : WebApplicationFactory<WebApiEntryPoi
             {
                 options.Domain = "konnect-test.auth0.local";
                 options.SeekerAudience = SeekerAudience;
-                options.EmployerAudience = EmployerAudience;
+                options.RecruiterAudience = RecruiterAudience;
             });
 
             services.AddSingleton<IPostConfigureOptions<JwtBearerOptions>>(

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Authorization/AudienceRequirementHandlerTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Authorization/AudienceRequirementHandlerTests.cs
@@ -1,0 +1,174 @@
+using System.Security.Claims;
+using Konnect.Infrastructure.Contracts.Enums;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.WebAPI.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+
+namespace Konnect.Tests.WebAPI.Authorization;
+
+/// <summary>
+/// Unit tests for <see cref="AudienceRequirementHandler"/>. The full pipeline
+/// (JwtBearer → policy → endpoint) is exercised in
+/// <see cref="AuthorizationPolicySweepTests"/>; this class isolates the
+/// branch-by-branch logic of the requirement handler so a regression in
+/// either of the two independent checks (audience claim, role) is caught
+/// without spinning up the host.
+/// </summary>
+public sealed class AudienceRequirementHandlerTests
+{
+    private const string SeekerAudience = "https://api.konnect.test/seeker";
+    private const string RecruiterAudience = "https://api.konnect.test/recruiter";
+
+    [Fact]
+    public async Task Should_Succeed_When_SeekerAudienceAndSeekerRoleMatch()
+    {
+        var context = BuildContext(
+            audience: AudienceType.JobSeeker,
+            audienceClaim: SeekerAudience,
+            roleClaim: JwtRoles.JobSeeker);
+
+        await BuildHandler().HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Should_Succeed_When_RecruiterAudienceAndRecruiterRoleMatch()
+    {
+        var context = BuildContext(
+            audience: AudienceType.Recruiter,
+            audienceClaim: RecruiterAudience,
+            roleClaim: JwtRoles.Recruiter);
+
+        await BuildHandler().HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Should_Fail_When_AudienceClaimMismatchesRequirement()
+    {
+        // Token has the seeker audience but the endpoint requires the recruiter
+        // audience — even if the role claim says "Recruiter", the token was
+        // never issued for the recruiter API and must be rejected.
+        var context = BuildContext(
+            audience: AudienceType.Recruiter,
+            audienceClaim: SeekerAudience,
+            roleClaim: JwtRoles.Recruiter);
+
+        await BuildHandler().HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Should_Fail_When_RoleClaimMismatchesRequirement()
+    {
+        // Audience says recruiter side, but the role claim is JobSeeker — the
+        // independent role check is what catches it.
+        var context = BuildContext(
+            audience: AudienceType.Recruiter,
+            audienceClaim: RecruiterAudience,
+            roleClaim: JwtRoles.JobSeeker);
+
+        await BuildHandler().HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Should_Fail_When_AudienceClaimIsMissing()
+    {
+        var context = BuildContext(
+            audience: AudienceType.Recruiter,
+            audienceClaim: null,
+            roleClaim: JwtRoles.Recruiter);
+
+        await BuildHandler().HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Should_Fail_When_RoleClaimIsMissing()
+    {
+        var context = BuildContext(
+            audience: AudienceType.Recruiter,
+            audienceClaim: RecruiterAudience,
+            roleClaim: null);
+
+        await BuildHandler().HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Should_Fail_When_ConfiguredAudienceUrlIsEmpty()
+    {
+        // Defensive: if Auth0Settings was misconfigured at startup so the URL
+        // is empty, the handler must not succeed on a token whose aud claim is
+        // also empty. Without this guard, an attacker who minted a token with
+        // aud="" would silently pass.
+        var settings = new Auth0Settings
+        {
+            Domain = "konnect-test.auth0.local",
+            SeekerAudience = string.Empty,
+            RecruiterAudience = string.Empty,
+        };
+        var handler = new AudienceRequirementHandler(Options.Create(settings));
+
+        var context = BuildContext(
+            audience: AudienceType.Recruiter,
+            audienceClaim: string.Empty,
+            roleClaim: JwtRoles.Recruiter);
+
+        await handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    private static AudienceRequirementHandler BuildHandler()
+    {
+        var settings = new Auth0Settings
+        {
+            Domain = "konnect-test.auth0.local",
+            SeekerAudience = SeekerAudience,
+            RecruiterAudience = RecruiterAudience,
+        };
+        return new AudienceRequirementHandler(Options.Create(settings));
+    }
+
+    private static AuthorizationHandlerContext BuildContext(
+        AudienceType audience,
+        string? audienceClaim,
+        string? roleClaim)
+    {
+        var claims = new List<Claim>();
+        if (audienceClaim is not null)
+        {
+            claims.Add(new Claim("aud", audienceClaim));
+        }
+
+        if (roleClaim is not null)
+        {
+            claims.Add(new Claim(KonnectClaimTypes.Role, roleClaim));
+        }
+
+        // RoleClaimType has to match what JwtBearer wires up in Program.cs —
+        // otherwise ClaimsPrincipal.IsInRole(...) looks at the wrong claim and
+        // the role check always returns false.
+        var identity = new ClaimsIdentity(
+            claims,
+            authenticationType: "Test",
+            nameType: KonnectClaimTypes.ExternalId,
+            roleType: KonnectClaimTypes.Role);
+        var principal = new ClaimsPrincipal(identity);
+
+        var requirement = new AudienceRequirement(audience);
+        return new AuthorizationHandlerContext(
+            [requirement],
+            principal,
+            resource: null);
+    }
+}

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Authorization/AuthorizationPolicySweepTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Authorization/AuthorizationPolicySweepTests.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Konnect.Infrastructure.Contracts.Companies;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.Infrastructure.Services.Onboarding;
+using Konnect.Tests.Infrastructure;
+using Konnect.Tests.WebAPI.Authentication.Fixtures;
+
+namespace Konnect.Tests.WebAPI.Authorization;
+
+/// <summary>
+/// One-stop authorization sweep across every policy-protected endpoint
+/// currently shipped: <c>/api/seeker/onboard</c>, <c>/api/recruiter/onboard</c>,
+/// <c>/api/recruiter/company</c>, and the GraphQL <c>recruiter</c> subtree.
+/// Each protected surface is exercised with the same matrix —
+/// no token (401), token from the opposite audience (403), and a token with
+/// the right audience claim but the wrong role (403). Happy-path 200s live
+/// in the per-feature test classes; this class is the cross-cutting boundary
+/// check that guarantees a regression in <c>AddKonnectAuthorization</c> can
+/// never silently weaken the policy on any single endpoint.
+/// </summary>
+[Collection(DatabaseTestSuite.Name)]
+public sealed class AuthorizationPolicySweepTests : IDisposable
+{
+    private readonly KonnectWebApplicationFactory _factory;
+
+    public AuthorizationPolicySweepTests(PostgresFixture postgresFixture)
+    {
+        _factory = new KonnectWebApplicationFactory
+        {
+            PostgresConnectionString = postgresFixture.ConnectionString,
+        };
+    }
+
+    public void Dispose() => _factory.Dispose();
+
+    public static TheoryData<string> RecruiterRestEndpoints => new()
+    {
+        "/api/recruiter/onboard",
+        "/api/recruiter/company",
+    };
+
+    public static TheoryData<string> SeekerRestEndpoints => new()
+    {
+        "/api/seeker/onboard",
+    };
+
+    [Theory]
+    [MemberData(nameof(RecruiterRestEndpoints))]
+    public async Task Should_Return401_When_RecruiterEndpointReceivesNoToken(string endpoint)
+    {
+        var client = _factory.CreateClient();
+
+        var response = await SendDefaultPayload(client, endpoint);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(SeekerRestEndpoints))]
+    public async Task Should_Return401_When_SeekerEndpointReceivesNoToken(string endpoint)
+    {
+        var client = _factory.CreateClient();
+
+        var response = await SendDefaultPayload(client, endpoint);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(RecruiterRestEndpoints))]
+    public async Task Should_Return403_When_RecruiterEndpointReceivesSeekerToken(string endpoint)
+    {
+        var token = CreateToken(
+            audience: KonnectWebApplicationFactory.SeekerAudience,
+            role: JwtRoles.JobSeeker);
+        var client = CreateAuthorizedClient(token);
+
+        var response = await SendDefaultPayload(client, endpoint);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(SeekerRestEndpoints))]
+    public async Task Should_Return403_When_SeekerEndpointReceivesRecruiterToken(string endpoint)
+    {
+        var token = CreateToken(
+            audience: KonnectWebApplicationFactory.RecruiterAudience,
+            role: JwtRoles.Recruiter);
+        var client = CreateAuthorizedClient(token);
+
+        var response = await SendDefaultPayload(client, endpoint);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(RecruiterRestEndpoints))]
+    public async Task Should_Return403_When_RecruiterEndpointReceivesRightAudienceButWrongRole(string endpoint)
+    {
+        // Defence-in-depth: token was issued for the recruiter API but the
+        // role claim is JobSeeker. Without the independent role check on the
+        // policy this would slip through on aud alone.
+        var token = CreateToken(
+            audience: KonnectWebApplicationFactory.RecruiterAudience,
+            role: JwtRoles.JobSeeker);
+        var client = CreateAuthorizedClient(token);
+
+        var response = await SendDefaultPayload(client, endpoint);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(SeekerRestEndpoints))]
+    public async Task Should_Return403_When_SeekerEndpointReceivesRightAudienceButWrongRole(string endpoint)
+    {
+        var token = CreateToken(
+            audience: KonnectWebApplicationFactory.SeekerAudience,
+            role: JwtRoles.Recruiter);
+        var client = CreateAuthorizedClient(token);
+
+        var response = await SendDefaultPayload(client, endpoint);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Should_ReturnGraphQLError_When_RecruiterScopedQueryHasNoToken()
+    {
+        var client = _factory.CreateClient();
+
+        var json = await PostRecruiterScopedQuery(client);
+
+        AssertGraphQLHasErrors(json);
+    }
+
+    [Fact]
+    public async Task Should_ReturnGraphQLError_When_RecruiterScopedQueryReceivesSeekerToken()
+    {
+        var token = CreateToken(
+            audience: KonnectWebApplicationFactory.SeekerAudience,
+            role: JwtRoles.JobSeeker);
+        var client = CreateAuthorizedClient(token);
+
+        var json = await PostRecruiterScopedQuery(client);
+
+        AssertGraphQLHasErrors(json);
+    }
+
+    [Fact]
+    public async Task Should_ReturnGraphQLError_When_RecruiterScopedQueryHasRightAudienceButWrongRole()
+    {
+        var token = CreateToken(
+            audience: KonnectWebApplicationFactory.RecruiterAudience,
+            role: JwtRoles.JobSeeker);
+        var client = CreateAuthorizedClient(token);
+
+        var json = await PostRecruiterScopedQuery(client);
+
+        AssertGraphQLHasErrors(json);
+    }
+
+    private string CreateToken(string audience, string role)
+        => _factory.TokenFactory.CreateToken(
+            audience,
+            additionalClaims:
+            [
+                new(KonnectClaimTypes.ExternalId, Guid.NewGuid().ToString()),
+                new(KonnectClaimTypes.Role, role),
+                new("email", "principal@example.test"),
+            ]);
+
+    private HttpClient CreateAuthorizedClient(string token)
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private static Task<HttpResponseMessage> SendDefaultPayload(HttpClient client, string endpoint)
+        => endpoint switch
+        {
+            "/api/seeker/onboard" => client.PostAsJsonAsync(
+                new Uri(endpoint, UriKind.Relative),
+                new OnboardJobSeekerInput(null, null, false)),
+            "/api/recruiter/onboard" => client.PostAsJsonAsync(
+                new Uri(endpoint, UriKind.Relative),
+                new OnboardRecruiterInput(
+                    CompanyName: "Acme",
+                    CompanySlug: $"acme-{Guid.NewGuid():N}",
+                    CompanyDescription: null,
+                    CompanyWebsiteUrl: null,
+                    FirstName: "Alice",
+                    LastName: "Anderson",
+                    JobTitle: "Recruiter")),
+            "/api/recruiter/company" => client.PutAsJsonAsync(
+                new Uri(endpoint, UriKind.Relative),
+                new UpdateCompanyInput("Acme", null, null)),
+            _ => throw new InvalidOperationException($"No default payload mapped for endpoint '{endpoint}'."),
+        };
+
+    private static async Task<string> PostRecruiterScopedQuery(HttpClient client)
+    {
+        var response = await client.PostAsJsonAsync(
+            new Uri("/graphql", UriKind.Relative),
+            new { query = "{ recruiter { company { slug } } }" });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    private static void AssertGraphQLHasErrors(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        Assert.True(
+            document.RootElement.TryGetProperty("errors", out _),
+            "Expected GraphQL response to contain an 'errors' array for the unauthorized request.");
+    }
+}

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Companies/RecruiterCompanyTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Companies/RecruiterCompanyTests.cs
@@ -127,7 +127,7 @@ public sealed class RecruiterCompanyTests : IDisposable
     private HttpClient CreateRecruiterClient(Guid externalId)
     {
         var token = _factory.TokenFactory.CreateToken(
-            audience: KonnectWebApplicationFactory.EmployerAudience,
+            audience: KonnectWebApplicationFactory.RecruiterAudience,
             additionalClaims:
             [
                 new(KonnectClaimTypes.ExternalId, externalId.ToString()),

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/JobSeekerOnboardingTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/JobSeekerOnboardingTests.cs
@@ -80,7 +80,7 @@ public sealed class JobSeekerOnboardingTests : IDisposable
     {
         var externalId = Guid.NewGuid();
         var token = factory.TokenFactory.CreateToken(
-            audience: KonnectWebApplicationFactory.EmployerAudience,
+            audience: KonnectWebApplicationFactory.RecruiterAudience,
             additionalClaims:
             [
                 new(KonnectClaimTypes.ExternalId, externalId.ToString()),

--- a/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/RecruiterOnboardingTests.cs
+++ b/Konnect.Platform/Konnect.Tests/WebAPI/Onboarding/RecruiterOnboardingTests.cs
@@ -144,7 +144,7 @@ public sealed class RecruiterOnboardingTests : IDisposable
     private HttpClient CreateClientWithRecruiterToken(Guid externalId, string email)
     {
         var token = factory.TokenFactory.CreateToken(
-            audience: KonnectWebApplicationFactory.EmployerAudience,
+            audience: KonnectWebApplicationFactory.RecruiterAudience,
             additionalClaims:
             [
                 new(KonnectClaimTypes.ExternalId, externalId.ToString()),

--- a/Konnect.Platform/Konnect.WebAPI/Authorization/AudienceRequirement.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Authorization/AudienceRequirement.cs
@@ -1,0 +1,16 @@
+using Konnect.Infrastructure.Contracts.Enums;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Konnect.WebAPI.Authorization;
+
+/// <summary>
+/// Pins an endpoint to one side of the marketplace. Carries the
+/// <see cref="AudienceType"/> the endpoint is meant for;
+/// <see cref="AudienceRequirementHandler"/> verifies both that the JWT
+/// <c>aud</c> claim matches the configured audience URL for that side AND
+/// that the principal carries the role expected for that side.
+/// </summary>
+public sealed class AudienceRequirement(AudienceType audience) : IAuthorizationRequirement
+{
+    public AudienceType Audience { get; } = audience;
+}

--- a/Konnect.Platform/Konnect.WebAPI/Authorization/AudienceRequirementHandler.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Authorization/AudienceRequirementHandler.cs
@@ -1,0 +1,54 @@
+using Konnect.Infrastructure.Contracts.Enums;
+using Konnect.Infrastructure.Services.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+
+namespace Konnect.WebAPI.Authorization;
+
+/// <summary>
+/// Evaluates <see cref="AudienceRequirement"/> against the current principal.
+/// The token must carry the <c>aud</c> claim matching the configured audience
+/// URL for the requirement's side AND the role expected for that side; both
+/// checks are independent so a token re-issued under the wrong audience (or
+/// with the wrong role claim) still fails. Audience URLs are read from
+/// <see cref="Auth0Settings"/> at evaluation time via
+/// <see cref="IOptions{TOptions}"/> so the integration-test fixture's
+/// in-memory override is picked up after <c>ConfigureTestServices</c> runs.
+/// </summary>
+public sealed class AudienceRequirementHandler(IOptions<Auth0Settings> auth0Options)
+    : AuthorizationHandler<AudienceRequirement>
+{
+    private readonly IOptions<Auth0Settings> _auth0Options = auth0Options;
+
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        AudienceRequirement requirement)
+    {
+        var settings = _auth0Options.Value;
+
+        var (expectedAudience, expectedRole) = requirement.Audience switch
+        {
+            AudienceType.JobSeeker => (settings.SeekerAudience, JwtRoles.JobSeeker),
+            AudienceType.Recruiter => (settings.RecruiterAudience, JwtRoles.Recruiter),
+            _ => (string.Empty, string.Empty),
+        };
+
+        if (string.IsNullOrEmpty(expectedAudience) || string.IsNullOrEmpty(expectedRole))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (!context.User.HasClaim("aud", expectedAudience))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (!context.User.IsInRole(expectedRole))
+        {
+            return Task.CompletedTask;
+        }
+
+        context.Succeed(requirement);
+        return Task.CompletedTask;
+    }
+}

--- a/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/JobSeekerOnboardingController.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/JobSeekerOnboardingController.cs
@@ -15,7 +15,7 @@ namespace Konnect.WebAPI.Controllers.Onboarding;
 /// </summary>
 [ApiController]
 [Route("api/seeker/onboard")]
-[Authorize(Roles = JwtRoles.JobSeeker)]
+[Authorize(Policy = AuthorizationPolicyNames.SeekerAudience)]
 public sealed class JobSeekerOnboardingController(IJobSeekerOnboardingService onboardingService) : ControllerBase
 {
     [HttpPost]

--- a/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/RecruiterOnboardingController.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Controllers/Onboarding/RecruiterOnboardingController.cs
@@ -17,7 +17,7 @@ namespace Konnect.WebAPI.Controllers.Onboarding;
 /// </summary>
 [ApiController]
 [Route("api/recruiter/onboard")]
-[Authorize(Roles = JwtRoles.Recruiter)]
+[Authorize(Policy = AuthorizationPolicyNames.RecruiterAudience)]
 public sealed class RecruiterOnboardingController(IRecruiterOnboardingService onboardingService) : ControllerBase
 {
     [HttpPost]

--- a/Konnect.Platform/Konnect.WebAPI/Controllers/Recruiter/RecruiterCompanyController.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Controllers/Recruiter/RecruiterCompanyController.cs
@@ -15,7 +15,7 @@ namespace Konnect.WebAPI.Controllers.Recruiter;
 /// </summary>
 [ApiController]
 [Route("api/recruiter/company")]
-[Authorize(Roles = JwtRoles.Recruiter)]
+[Authorize(Policy = AuthorizationPolicyNames.RecruiterAudience)]
 public sealed class RecruiterCompanyController(ICompanyCommandService companyCommandService) : ControllerBase
 {
     [HttpPut]

--- a/Konnect.Platform/Konnect.WebAPI/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+using Konnect.Infrastructure.Contracts.Enums;
+using Konnect.Infrastructure.Services.Authentication;
+using Konnect.WebAPI.Authorization;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Konnect.WebAPI.Extensions;
+
+/// <summary>
+/// Registers Konnect's named authorization policies and the requirement
+/// handlers that back them. One well-known place to look for what a policy
+/// name means — the constants live in
+/// <see cref="AuthorizationPolicyNames"/>, the requirement + handler live
+/// alongside in <c>Konnect.WebAPI/Authorization</c>, and the wiring lives
+/// here so <c>Program.cs</c> stays small.
+/// </summary>
+public static class AuthorizationServiceCollectionExtensions
+{
+    public static IServiceCollection AddKonnectAuthorization(this IServiceCollection services)
+    {
+        services.AddSingleton<IAuthorizationHandler, AudienceRequirementHandler>();
+
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy(
+                AuthorizationPolicyNames.SeekerAudience,
+                policy => policy
+                    .RequireAuthenticatedUser()
+                    .AddRequirements(new AudienceRequirement(AudienceType.JobSeeker)));
+
+            options.AddPolicy(
+                AuthorizationPolicyNames.RecruiterAudience,
+                policy => policy
+                    .RequireAuthenticatedUser()
+                    .AddRequirements(new AudienceRequirement(AudienceType.Recruiter)));
+        });
+
+        return services;
+    }
+}

--- a/Konnect.Platform/Konnect.WebAPI/Program.cs
+++ b/Konnect.Platform/Konnect.WebAPI/Program.cs
@@ -3,6 +3,7 @@ using Konnect.Infrastructure.Repositories;
 using Konnect.Infrastructure.Services.Authentication;
 using Konnect.Repositories.Extensions;
 using Konnect.Services.Extensions;
+using Konnect.WebAPI.Extensions;
 using Konnect.WebAPI.Middleware;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Options;
@@ -69,13 +70,13 @@ builder.Services
             ValidAudiences =
             [
                 auth0Settings.SeekerAudience,
-                auth0Settings.EmployerAudience,
+                auth0Settings.RecruiterAudience,
             ],
             ValidateIssuerSigningKey = true,
             ValidateLifetime = true,
             // The Post-Login Action stamps the role under our namespaced
-            // claim — wire it through so [Authorize(Roles = "JobSeeker")]
-            // reads the right value.
+            // claim — wire it through so AudienceRequirementHandler's
+            // ClaimsPrincipal.IsInRole(...) check reads the right value.
             RoleClaimType = KonnectClaimTypes.Role,
             NameClaimType = KonnectClaimTypes.ExternalId,
         };
@@ -85,7 +86,7 @@ builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer();
 
-builder.Services.AddAuthorization();
+builder.Services.AddKonnectAuthorization();
 
 var app = builder.Build();
 

--- a/Konnect.Platform/Konnect.WebAPI/appsettings.Development.json
+++ b/Konnect.Platform/Konnect.WebAPI/appsettings.Development.json
@@ -11,6 +11,6 @@
   "Auth0": {
     "Domain": "dev-7tezygfwayj84twt.us.auth0.com",
     "SeekerAudience": "https://api.konnect.dev/seeker",
-    "EmployerAudience": "https://api.konnect.dev/recruiter"
+    "RecruiterAudience": "https://api.konnect.dev/recruiter"
   }
 }

--- a/Konnect.Platform/Konnect.WebAPI/appsettings.json
+++ b/Konnect.Platform/Konnect.WebAPI/appsettings.json
@@ -12,6 +12,6 @@
   "Auth0": {
     "Domain": "",
     "SeekerAudience": "",
-    "EmployerAudience": ""
+    "RecruiterAudience": ""
   }
 }

--- a/wikis/Architecture.md
+++ b/wikis/Architecture.md
@@ -96,7 +96,7 @@ builder.Services.AddKonnectServices();       // onboarding + future services
 // Auth0 OIDC — JwtBearer scheme accepts tokens for both seeker + recruiter audiences
 builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme).Configure<IOptions<Auth0Settings>>(...);
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer();
-builder.Services.AddAuthorization();
+builder.Services.AddKonnectAuthorization();   // named policies: SeekerAudience, RecruiterAudience
 
 // ...
 
@@ -113,18 +113,18 @@ Today, the routes that respond are:
 | Route | What it returns | Auth |
 |---|---|---|
 | `GET /api/me` | The authenticated caller's `external_id`, `role`, and `email`, distilled from JWT claims. Useful as an auth smoke test from the SPAs. | `[Authorize]` |
-| `POST /api/recruiter/onboard` | Provisions the `Company` + first `RecruiterUser` row after the SPA's first Auth0 sign-in. Idempotent on the JWT `external_id` claim. See [Onboarding](api/Onboarding). | `[Authorize(Roles = "Recruiter")]` |
-| `POST /api/seeker/onboard` | Provisions the `JobSeekerUser` row after the SPA's first Auth0 sign-in. Idempotent. | `[Authorize(Roles = "JobSeeker")]` |
-| `PUT /api/recruiter/company` | Updates the recruiter's own company (name / description / website). Slug is not editable here. See [GraphQL — Companies](api/GraphQL-Companies). | `[Authorize(Roles = "Recruiter")]` |
+| `POST /api/recruiter/onboard` | Provisions the `Company` + first `RecruiterUser` row after the SPA's first Auth0 sign-in. Idempotent on the JWT `external_id` claim. See [Onboarding](api/Onboarding). | `RecruiterAudience` policy |
+| `POST /api/seeker/onboard` | Provisions the `JobSeekerUser` row after the SPA's first Auth0 sign-in. Idempotent. | `SeekerAudience` policy |
+| `PUT /api/recruiter/company` | Updates the recruiter's own company (name / description / website). Slug is not editable here. See [GraphQL — Companies](api/GraphQL-Companies). | `RecruiterAudience` policy |
 | `POST /graphql` — `Query.healthcheck` | Schema smoke test — see [`Konnect.GraphQL/Schema/Query.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.GraphQL/Schema/Query.cs) | anonymous |
 | `POST /graphql` — `Query.company(slug)` | Public lookup of a company by URL slug. Powers the public profile page. | anonymous |
-| `POST /graphql` — `Query.recruiter.company` | The recruiter's own company. Target derived from the JWT `external_id`, never from arguments. See [GraphQL — Companies](api/GraphQL-Companies). | `@authorize(roles: ["Recruiter"])` on the `recruiter` wrapper |
+| `POST /graphql` — `Query.recruiter.company` | The recruiter's own company. Target derived from the JWT `external_id`, never from arguments. See [GraphQL — Companies](api/GraphQL-Companies). | `RecruiterAudience` policy on the `recruiter` wrapper |
 | `GET /graphql` *(dev only)* | Banana Cake Pop / Nitro UI | anonymous |
 | `GET /openapi/v1.json` *(dev only)* | OpenAPI document | anonymous |
 
 The split between transports is deliberate: **GraphQL serves queries, REST serves commands.** The schema therefore has a `Query` root but no `Mutation` root — every state-changing operation lives on a REST controller. This maps cleanly onto the CQRS-lite split in `Konnect.Services/<DomainArea>/{Queries,Commands}/` (query services back resolvers, command services back controllers), so changing transport or scaling the read side independently is a one-layer change.
 
-Authentication is delegated to **Auth0** — Konnect never stores passwords, never issues JWTs, and holds no refresh-token state. The full picture (tenant setup, the two Auth0 Actions, the audience-split, the operational note about the Pre-User-Registration Action) lives on the [Authentication — Auth0](api/Authentication-Auth0) page. Identity-to-domain handshake (the post-Auth0 onboarding step that creates the `JobSeekerUser` / `RecruiterUser` + `Company` rows) is documented on the [Onboarding](api/Onboarding) page.
+Authentication is delegated to **Auth0** — Konnect never stores passwords, never issues JWTs, and holds no refresh-token state. The full picture (tenant setup, the two Auth0 Actions, the audience-split, the operational note about the Pre-User-Registration Action) lives on the [Authentication — Auth0](api/Authentication-Auth0) page. Identity-to-domain handshake (the post-Auth0 onboarding step that creates the `JobSeekerUser` / `RecruiterUser` + `Company` rows) is documented on the [Onboarding](api/Onboarding) page. The named-policy model that gates every protected endpoint — including the audience-claim check that complements Auth0's audience-split — is documented on the [Authorization](api/Authorization) page.
 
 Audit timestamps (`created_at`, `updated_at`) are owned by Postgres: a column default plus a `BEFORE UPDATE` trigger calling a shared `set_updated_at()` function. Application services never assign these — keeps the application clock and DB clock from skewing, and the schema stays correct even if a non-EF caller (psql, ETL) writes rows. See [`Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.Repositories/Migrations/20260508121429_AddDbManagedTimestamps.cs).
 
@@ -157,6 +157,7 @@ A single workflow at [`.github/workflows/ci.yml`](https://github.com/win-son-dev
 ## Where to look next
 
 - [Authentication — Auth0](api/Authentication-Auth0) — tenant setup, the two Auth0 Actions, audience-split, dev / test / prod config.
+- [Authorization](api/Authorization) — the named-policy model that gates every protected endpoint.
 - [Local Development](Local-Development) — getting a working dev environment.
 - [Infrastructure overview](infrastructure/Overview) — what runs in compose, why, and how to operate it.
 - [CI Pipeline](infrastructure/CI-Pipeline) — what gates a merge.

--- a/wikis/Home.md
+++ b/wikis/Home.md
@@ -19,6 +19,7 @@ This wiki is the deep-dive layer for collaborators. The repo `README.md` is the 
 - **[Features](Features)** — index of every feature Konnect ships or plans to ship, with status (Planned / In Progress / Shipped) and links to the GitHub Story that holds the spec. Per-feature deep-dive pages get added under `wikis/features/` when each feature ships.
 - **API** — endpoint pages get added when each endpoint is implemented.
   - [Authentication — Auth0](api/Authentication-Auth0)
+  - [Authorization](api/Authorization)
   - [Onboarding](api/Onboarding)
   - [GraphQL — Companies](api/GraphQL-Companies)
 

--- a/wikis/api/Authorization.md
+++ b/wikis/api/Authorization.md
@@ -1,0 +1,62 @@
+# Authorization
+
+Authorization is **policy-driven**, not role-attribute-driven. Every protected endpoint declares one of a small set of named policies, and the policy encodes both the JWT `aud` claim check and the role check in one gate.
+
+This page documents the policies that exist today, how a request flows through them, and how to add a new endpoint to the right policy. The audience-split itself (why the platform has two `aud` values in the first place) lives on the [Authentication — Auth0](Authentication-Auth0) page.
+
+## Why policies, not roles
+
+A `[Authorize(Roles = "Recruiter")]` attribute only checks the role claim. It does not verify which API the token was minted for, so a token issued for the seeker side that somehow carries the `Recruiter` role would still pass the gate. Konnect's authorization model treats the JWT audience as a first-class security boundary — every policy enforces audience + role together. The two checks are independent: a token with the right audience but the wrong role fails, and vice versa.
+
+Beyond audience boundaries, policies are also where the future per-resource checks land — `OwnsPostingRequirement` (verify the recruiter editing a job actually owns it) cannot be expressed as a role attribute because it needs to read the database. The handler pattern scales; the attribute pattern does not.
+
+## Policy table
+
+| Policy name | Requires | Used by |
+|---|---|---|
+| `SeekerAudience` | JWT `aud == Auth0:SeekerAudience` AND role claim `JobSeeker` | `POST /api/seeker/onboard` |
+| `RecruiterAudience` | JWT `aud == Auth0:RecruiterAudience` AND role claim `Recruiter` | `POST /api/recruiter/onboard`, `PUT /api/recruiter/company`, GraphQL `Query.recruiter` subtree |
+
+Both policies also implicitly require `RequireAuthenticatedUser()` — an anonymous request gets 401 before the audience handler runs.
+
+The policy names live as constants in [`Konnect.Infrastructure/Services/Authentication/AuthorizationPolicyNames.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.Infrastructure/Services/Authentication/AuthorizationPolicyNames.cs) so both `Konnect.WebAPI` and `Konnect.GraphQL` reference the same strings.
+
+## How a request flows through the gate
+
+```
+Request with bearer token
+        ↓
+1. JwtBearer middleware
+   - Validates signature, issuer, audience, expiry
+   - Hydrates ClaimsPrincipal from the JWT (with MapInboundClaims=false,
+     so claim names are kept as raw JWT shortnames like "aud")
+        ↓
+2. KonnectAuthenticationMiddleware
+   - Anonymous: passes through
+   - Authenticated: rejects (401) if the namespaced external_id or role
+     claim is missing/malformed
+        ↓
+3. [Authorize(Policy = "...")] on the controller / GraphQL field
+   - Resolves the named policy
+   - AudienceRequirementHandler reads IOptions<Auth0Settings> and verifies
+     the principal's "aud" claim AND IsInRole(...)
+   - All checks pass → endpoint runs
+   - Any check fails → 403 (REST) or GraphQL "errors" array (GraphQL)
+```
+
+The 401 vs 403 split is intentional: 401 means "we cannot tell who you are", 403 means "we know who you are and this is not for you." A seeker token sent to a recruiter endpoint passes step 1 (the token is valid), passes step 2 (claims are well-formed), and only fails at step 3 — that's 403, not 401.
+
+## Adding a new endpoint
+
+1. **Decide which policy fits.** Recruiter-only endpoint → `RecruiterAudience`. Seeker-only endpoint → `SeekerAudience`. A public-by-default endpoint that just needs an authenticated caller (today only `/api/me`) uses bare `[Authorize]`.
+2. **Annotate the controller / GraphQL field.** REST controllers use `[Authorize(Policy = AuthorizationPolicyNames.RecruiterAudience)]`; HotChocolate resolvers use the same `Policy = ...` form on `HotChocolate.Authorization.AuthorizeAttribute`.
+3. **Cover the audience boundary in the integration sweep.** [`Konnect.Tests/WebAPI/Authorization/AuthorizationPolicySweepTests.cs`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.Tests/WebAPI/Authorization/AuthorizationPolicySweepTests.cs) drives a matrix of no-token / wrong-audience / right-audience-wrong-role per endpoint. Adding a new endpoint to the table extends the sweep automatically — there's no per-endpoint copy/paste of audience-boundary tests.
+
+## What is intentionally not here
+
+Two policies that the original spec listed are deferred until their consumers exist:
+
+- **`CompanyAdminPolicy`** — Phase 1 is one recruiter per company, so the admin-vs-member distinction gates nothing. Lands when team management ships.
+- **`OwnsPostingRequirement`** — verifies the recruiter editing a posting owns its company. Lands together with the JobPosting REST endpoints (issue #25), where it has its first caller.
+
+Both are tracked in the Phase 1 Story (#20). The policy registration in [`AuthorizationServiceCollectionExtensions`](https://github.com/win-son-dev/konnect-server/blob/main/Konnect.Platform/Konnect.WebAPI/Extensions/AuthorizationServiceCollectionExtensions.cs) is the single place they get added when those issues land.


### PR DESCRIPTION
Closes #26.

## Summary

- Replaces inline `[Authorize(Roles = ...)]` attributes with two named policies — `SeekerAudience` and `RecruiterAudience` — that verify the JWT `aud` claim **and** the role claim independently. A token issued for the wrong audience can no longer slip through on the role claim alone (and vice versa).
- Adds an integration sweep (`AuthorizationPolicySweepTests`) that drives `401` / `403` / right-audience-wrong-role across every policy-protected REST endpoint and the recruiter-scoped GraphQL subtree. Pinned at the boundary so any future regression in `AddKonnectAuthorization` fails CI loudly.
- Finishes the deferred `EmployerAudience` → `RecruiterAudience` rename (config key, `Auth0Settings`, `appsettings.*`, test fixture, existing tests).
- New wiki page `wikis/api/Authorization.md` plus `wikis/Architecture.md` updates so the routes table and `Program.cs` snippet reflect the policy-driven model.

## Scope decisions (vs the original issue)

- **`CompanyAdminPolicy`** — deferred. No caller until multi-recruiter teams ship; matches `decision_company_admin_deferred.md`.
- **`OwnsPostingRequirement` / `OwnsPostingHandler`** — deferred. No JobPosting endpoints to gate until #25 lands; building it now would be an abstraction with no caller. The DI extension is the single place both land when #25 is in flight.

Both are flagged on the new wiki page.

## Files

- New: `AuthorizationPolicyNames`, `AudienceRequirement`, `AudienceRequirementHandler`, `AuthorizationServiceCollectionExtensions`, two test classes, `wikis/api/Authorization.md`.
- Modified: 3 controllers + 2 GraphQL files (role → policy), `Auth0Settings`, both `appsettings.*`, `Program.cs`, test fixture, 5 existing tests, `wikis/Architecture.md`, `wikis/Home.md`.

## Tests

- 19 new (7 unit handler tests + 12 integration sweep tests)
- Full suite: **88 passed / 0 failed**

## Test plan

- [x] `AudienceRequirementHandlerTests` — succeed/fail matrix for each (audience × role) combination, including missing claims and empty configured audience
- [x] `AuthorizationPolicySweepTests` — 401 / 403 (cross-audience) / 403 (right-audience-wrong-role) per protected endpoint + recruiter-scoped GraphQL
- [x] Existing tests continue to pass after the `EmployerAudience` → `RecruiterAudience` rename
- [x] `dotnet build` clean (0 warnings, 0 errors)